### PR TITLE
Adding more exception handling for REST API responses in Android Core SDK

### DIFF
--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/auth/LiAuthServiceImpl.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/auth/LiAuthServiceImpl.java
@@ -462,16 +462,21 @@ public class LiAuthServiceImpl implements LiAuthService {
         LiBaseResponse resp = authRestClient.refreshTokenSync(mContext, liRefreshTokenRequest);
         Gson gson = new Gson();
         JsonObject dataObject = resp.getData();
-        if (dataObject.has("response")) {
-            JsonObject responseObj = dataObject.get("response").getAsJsonObject();
-            if (responseObj.has("data")) {
-                JsonElement dataJsonElement = responseObj.get("data");
-                tokenResponse = gson.fromJson(dataJsonElement, LiTokenResponse.class);
-                tokenResponse.setExpiresAt(LiCoreSDKUtils.getTime(tokenResponse.getExpiresIn()));
-                JsonObject obj = dataJsonElement.getAsJsonObject();
-                obj.addProperty("expiresAt", tokenResponse.getExpiresAt());
-                tokenResponse.setJsonString(String.valueOf(obj));
+        try {
+            if (dataObject.has("response")) {
+                JsonObject responseObj = dataObject.get("response").getAsJsonObject();
+                if (responseObj.has("data")) {
+                    JsonElement dataJsonElement = responseObj.get("data");
+                    tokenResponse = gson.fromJson(dataJsonElement, LiTokenResponse.class);
+                    tokenResponse.setExpiresAt(LiCoreSDKUtils.getTime(tokenResponse.getExpiresIn()));
+                    JsonObject obj = dataJsonElement.getAsJsonObject();
+                    obj.addProperty("expiresAt", tokenResponse.getExpiresAt());
+                    tokenResponse.setJsonString(String.valueOf(obj));
+                }
             }
+        } catch (RuntimeException ex) {
+            ex.printStackTrace();
+            throw LiRestResponseException.runtimeError("Error refreshing access token");
         }
         if (tokenResponse == null) {
             throw LiRestResponseException.runtimeError("Error refreshing access token");

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/rest/LiAuthRestClient.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/rest/LiAuthRestClient.java
@@ -199,7 +199,12 @@ public class LiAuthRestClient {
     private void checkResponse(Response response, @NonNull LiAuthAsyncRequestCallback callback, String error) throws LiRestResponseException, IOException {
         if (response != null) {
             if (response.code() == LiCoreSDKConstants.HTTP_CODE_SUCCESSFUL && response.body() != null) {
-                callback.onSuccess(getLiBaseResponseFromResponse(response));
+                try {
+                    callback.onSuccess(getLiBaseResponseFromResponse(response));
+                } catch (RuntimeException ex) {
+                    ex.printStackTrace();
+                    throw LiRestResponseException.runtimeError(ex.getMessage());
+                }
             } else {
                 Log.e(LI_LOG_TAG, error);
                 callback.onError(new LiRestResponseException(response.code(), error, response.code()));


### PR DESCRIPTION
Adding more exception handling for REST API responses in Android Core SDK. 

* Add  `try` ... `catch` to handle `RuntimeException` which could be thrown from the `onSuccess` callback of `LiAuthAsyncRequestCallback`