### PR TITLE
Improve initialisation flow in the SDK

### DIFF
--- a/configs/style-checks.xml
+++ b/configs/style-checks.xml
@@ -112,8 +112,12 @@
         <module name="TypeName">
             <message key="name.invalidPattern" value="Type name ''{0}'' must match pattern ''{1}''." />
         </module>
-        <module name="StaticVariableName">
+        <module name="ConstantName">
             <property name="format" value="^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$" />
+            <message key="name.invalidPattern" value="Constant name ''{0}'' must match pattern ''{1}''." />
+        </module>
+        <module name="StaticVariableName">
+            <property name="format" value="^[a-z][a-zA-Z0-9]*$" />
             <message key="name.invalidPattern" value="Member name ''{0}'' must match pattern ''{1}''." />
         </module>
         <module name="MemberName">

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/auth/LiAppCredentials.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/auth/LiAppCredentials.java
@@ -70,7 +70,7 @@ public final class LiAppCredentials {
     private final String ssoAuthorizeUri;
 
     /**
-     * Default private constructor for Lia SDK Credentials.
+     * Default public constructor for Lia SDK Credentials.
      *
      * @param clientName     The client name.
      * @param clientKey      The client Id.
@@ -79,8 +79,8 @@ public final class LiAppCredentials {
      * @param communityURL   The LIA community's URL.
      * @param apiGatewayHost API gateway host.
      */
-    private LiAppCredentials(@NonNull String clientName, @NonNull String clientKey, @NonNull String clientSecret,
-                             @NonNull String tenantId, @NonNull String communityURL, @NonNull String apiGatewayHost) {
+    public LiAppCredentials(@NonNull String clientName, @NonNull String clientKey, @NonNull String clientSecret,
+                            @NonNull String tenantId, @NonNull String communityURL, @NonNull String apiGatewayHost) {
         this.clientName = LiCoreSDKUtils.checkNullOrNotEmpty(clientName, "clientName was empty");
         this.clientKey = LiCoreSDKUtils.checkNullOrNotEmpty(clientKey, "clientKey was empty");
         this.clientSecret = LiCoreSDKUtils.checkNullOrNotEmpty(clientSecret, "clientSecret was empty");
@@ -195,6 +195,8 @@ public final class LiAppCredentials {
 
     /**
      * Builder to create instances of {@link LiAppCredentials}.
+     *
+     * @deprecated Use the default public constructor {@link #LiAppCredentials(String, String, String, String, String, String)} instead.
      */
     public static final class Builder {
 

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/auth/LiAppCredentials.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/auth/LiAppCredentials.java
@@ -66,21 +66,13 @@ public final class LiAppCredentials {
      */
     private LiAppCredentials(@NonNull String clientName, @NonNull String clientKey, @NonNull String clientSecret,
                              @NonNull String tenantId, @NonNull String communityURL, @NonNull String apiGatewayHost) {
+        this.clientName = LiCoreSDKUtils.checkNullOrNotEmpty(clientName, "clientName was empty");
+        this.clientKey = LiCoreSDKUtils.checkNullOrNotEmpty(clientKey, "clientKey was empty");
+        this.clientSecret = LiCoreSDKUtils.checkNullOrNotEmpty(clientSecret, "clientSecret was empty");
+        this.tenantId = LiCoreSDKUtils.checkNullOrNotEmpty(tenantId, "tenantId was empty");
 
-        LiCoreSDKUtils.checkNullOrNotEmpty(clientName, "clientName was empty");
-        LiCoreSDKUtils.checkNullOrNotEmpty(clientKey, "clientKey was empty");
-        LiCoreSDKUtils.checkNullOrNotEmpty(clientSecret, "clientSecret was empty");
-        LiCoreSDKUtils.checkNullOrNotEmpty(tenantId, "tenantId was empty");
-        LiCoreSDKUtils.checkNullOrNotEmpty(communityURL, "communityURL was empty");
-        LiCoreSDKUtils.checkNullOrNotEmpty(apiGatewayHost, "apiGatewayHost was empty");
-
-        this.clientName = clientName;
-        this.clientKey = clientKey;
-        this.clientSecret = clientSecret;
-        this.tenantId = tenantId;
-
-        this.communityUri = Uri.parse(communityURL);
-        this.apiGatewayHost = Uri.parse(apiGatewayHost);
+        this.communityUri = Uri.parse(LiCoreSDKUtils.checkNullOrNotEmpty(communityURL, "communityURL was empty"));
+        this.apiGatewayHost = Uri.parse(LiCoreSDKUtils.checkNullOrNotEmpty(apiGatewayHost, "apiGatewayHost was empty"));
 
         this.redirectUri = buildRedirectUri(communityUri);
         this.ssoAuthorizeUri = communityURL + "api/2.0/auth/authorize";

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/auth/LiAppCredentials.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/auth/LiAppCredentials.java
@@ -18,26 +18,32 @@ package lithium.community.android.sdk.auth;
 
 import android.net.Uri;
 import android.support.annotation.NonNull;
-import android.text.TextUtils;
-
-import java.net.MalformedURLException;
 
 import lithium.community.android.sdk.utils.LiCoreSDKUtils;
 import lithium.community.android.sdk.utils.LiUriUtils;
 
 /**
- * A credentials object representing client application developer key and secret. It also includes
- * which community the developer app wishes to connect to.
+ * The credentials for initializing the LIA SDK.
  */
 public final class LiAppCredentials {
 
-    public static final String SDK_SUFFIX = "-sdk";
+    @NonNull
+    private final String clientName;
+
+    @NonNull
+    private final String tenantId;
+
     @NonNull
     private final String clientKey;
+
     @NonNull
     private final String clientSecret;
+
     @NonNull
     private final Uri communityUri;
+
+    @NonNull
+    private final Uri apiGatewayHost;
 
     @NonNull
     private final Uri authorizeUri;
@@ -45,69 +51,77 @@ public final class LiAppCredentials {
     @NonNull
     private final String redirectUri;
 
+    @NonNull
     private final String ssoAuthorizeUri;
 
-    private final String tenantId;
-
-    private final String apiProxyHost;
-
-    private final String clientAppName;
-
     /**
-     * private constructor.
+     * Default public constructor for Lia SDK Credentials.
      *
-     * @param clientKey    This is client Id.
-     * @param clientSecret This is client secret.
-     * @param communityURL This is the URL of the community.
-     * @param tenantId     tenant ID for the community.
-     * @param apiProxyHost API proxy host.
-     * @throws MalformedURLException If the community URL is not valid this exception is thrown
+     * @param clientName     The client name.
+     * @param clientKey      The client Id.
+     * @param clientSecret   The client secret.
+     * @param tenantId       tenant ID of the community.
+     * @param communityURL   The LIA community's URL.
+     * @param apiGatewayHost API gateway host.
      */
-    private LiAppCredentials(@NonNull String clientKey, @NonNull String clientSecret,
-            @NonNull String communityURL, @NonNull String tenantId, @NonNull String apiProxyHost,
-            @NonNull String clientAppName)
-            throws MalformedURLException {
-        LiCoreSDKUtils.checkNullOrNotEmpty(clientKey, "clientKey cannot be empty");
-        LiCoreSDKUtils.checkNullOrNotEmpty(clientSecret, "clientKey cannot be empty");
-        LiCoreSDKUtils.checkNullOrNotEmpty(communityURL, "communityURL cannot be empty");
-        LiCoreSDKUtils.checkNullOrNotEmpty(clientAppName, "clientAppName cannot be empty");
-        LiCoreSDKUtils.checkNullOrNotEmpty(tenantId, "tenant ID cannot be empty");
-        LiCoreSDKUtils.checkNullOrNotEmpty(apiProxyHost, "apiProxyHost cannot be empty");
+    private LiAppCredentials(@NonNull String clientName, @NonNull String clientKey, @NonNull String clientSecret,
+                             @NonNull String tenantId, @NonNull String communityURL, @NonNull String apiGatewayHost) {
+
+        LiCoreSDKUtils.checkNullOrNotEmpty(clientName, "clientName was empty");
+        LiCoreSDKUtils.checkNullOrNotEmpty(clientKey, "clientKey was empty");
+        LiCoreSDKUtils.checkNullOrNotEmpty(clientSecret, "clientSecret was empty");
+        LiCoreSDKUtils.checkNullOrNotEmpty(tenantId, "tenantId was empty");
+        LiCoreSDKUtils.checkNullOrNotEmpty(communityURL, "communityURL was empty");
+        LiCoreSDKUtils.checkNullOrNotEmpty(apiGatewayHost, "apiGatewayHost was empty");
+
+        this.clientName = clientName;
         this.clientKey = clientKey;
         this.clientSecret = clientSecret;
+        this.tenantId = tenantId;
+
         this.communityUri = Uri.parse(communityURL);
-        this.authorizeUri = this.communityUri.buildUpon().path("auth/oauth2/authorize").build();
+        this.apiGatewayHost = Uri.parse(apiGatewayHost);
+
         this.redirectUri = buildRedirectUri(communityUri);
         this.ssoAuthorizeUri = communityURL + "api/2.0/auth/authorize";
-        this.tenantId = tenantId;
-        this.apiProxyHost = apiProxyHost;
-        if (!TextUtils.isEmpty(clientAppName)) {
-            this.clientAppName = clientAppName;
-        } else {
-            this.clientAppName = tenantId + SDK_SUFFIX;
-        }
+        this.authorizeUri = this.communityUri.buildUpon().path("auth/oauth2/authorize").build();
     }
 
     private static String buildRedirectUri(Uri communityUri) {
         return LiUriUtils.reverseDomainName(communityUri) + "://oauth2callback";
     }
 
-    public String getClientAppName() {
-        return clientAppName;
+    @NonNull
+    public String getClientName() {
+        return clientName;
     }
 
+    @NonNull
     public String getClientKey() {
         return clientKey;
     }
 
+    @NonNull
     public String getClientSecret() {
         return clientSecret;
     }
 
+    @NonNull
+    public String getTenantId() {
+        return tenantId;
+    }
+
+    @NonNull
     public Uri getCommunityUri() {
         return communityUri;
     }
 
+    @NonNull
+    public Uri getApiGatewayHost() {
+        return apiGatewayHost;
+    }
+
+    @NonNull
     public Uri getAuthorizeUri() {
         return authorizeUri;
     }
@@ -117,105 +131,182 @@ public final class LiAppCredentials {
         return redirectUri;
     }
 
-    public String getTenantId() {
-        return tenantId;
-    }
-
+    @NonNull
     public String getSsoAuthorizeUri() {
         return ssoAuthorizeUri;
     }
 
+    /**
+     * @return The client name
+     * @deprecated Use {@link #getClientName()} instead.
+     */
+    @NonNull
+    public String getClientAppName() {
+        return clientName;
+    }
+
+    /**
+     * @return the API Gateways host address
+     * @deprecated Use {@link #getApiGatewayHost()}
+     */
+    @NonNull
     public String getApiProxyHost() {
-        return apiProxyHost;
+        return getApiGatewayHost().toString();
     }
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (o == null || getClass() != o.getClass()) {
-            return false;
-        }
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
 
         LiAppCredentials that = (LiAppCredentials) o;
 
-        if (!clientKey.equals(that.clientKey)) {
-            return false;
-        }
-        if (!clientSecret.equals(that.clientSecret)) {
-            return false;
-        }
-        if (!communityUri.equals(that.communityUri)) {
-            return false;
-        }
-        if (!authorizeUri.equals(that.authorizeUri)) {
-            return false;
-        }
-        return redirectUri.equals(that.redirectUri);
-
+        if (!clientName.equals(that.clientName)) return false;
+        if (!tenantId.equals(that.tenantId)) return false;
+        if (!clientKey.equals(that.clientKey)) return false;
+        if (!clientSecret.equals(that.clientSecret)) return false;
+        if (!communityUri.equals(that.communityUri)) return false;
+        if (!apiGatewayHost.equals(that.apiGatewayHost)) return false;
+        if (!authorizeUri.equals(that.authorizeUri)) return false;
+        if (!redirectUri.equals(that.redirectUri)) return false;
+        return ssoAuthorizeUri.equals(that.ssoAuthorizeUri);
     }
 
     @Override
     public int hashCode() {
-        int result = clientKey.hashCode();
+        int result = clientName.hashCode();
+        result = 31 * result + tenantId.hashCode();
+        result = 31 * result + clientKey.hashCode();
         result = 31 * result + clientSecret.hashCode();
         result = 31 * result + communityUri.hashCode();
+        result = 31 * result + apiGatewayHost.hashCode();
         result = 31 * result + authorizeUri.hashCode();
         result = 31 * result + redirectUri.hashCode();
+        result = 31 * result + ssoAuthorizeUri.hashCode();
         return result;
     }
 
     /**
-     * Creates instances of {@link LiAppCredentials}.
+     * Builder to create instances of {@link LiAppCredentials}.
      */
     public static final class Builder {
+
+        private String clientName;
         private String clientKey;
         private String clientSecret;
-        private String communityUri;
         private String tenantId;
-        private String apiProxyHost;
-        private String clientAppName;
+        private String communityUri;
+        private String apiGatewayUri;
 
+        /**
+         * Default public constructor for the builder.
+         */
         public Builder() {
         }
 
+        /**
+         * Set the client name.
+         *
+         * @param clientName the client name.
+         * @return this builder.
+         */
+        public Builder setClientName(@NonNull String clientName) {
+            this.clientName = clientName;
+            return this;
+        }
+
+        /**
+         * Set the client key.
+         *
+         * @param clientKey the client key.
+         * @return this builder.
+         */
         @NonNull
         public Builder setClientKey(@NonNull String clientKey) {
             this.clientKey = clientKey;
             return this;
         }
 
+        /**
+         * Set the client secret.
+         *
+         * @param clientSecret the client secret.
+         * @return this builder.
+         */
         @NonNull
         public Builder setClientSecret(@NonNull String clientSecret) {
             this.clientSecret = clientSecret;
             return this;
         }
 
+        /**
+         * Set the tenant Id.
+         *
+         * @param tenantId the tenant Id.
+         * @return this builder.
+         */
         @NonNull
-        public Builder setTenantId(String tenantId) {
+        public Builder setTenantId(@NonNull String tenantId) {
             this.tenantId = tenantId;
             return this;
         }
 
+        /**
+         * Set the LIA community URL.
+         *
+         * @param communityUri the LIA community URL.
+         * @return this builder.
+         */
         @NonNull
         public Builder setCommunityUri(@NonNull String communityUri) {
             this.communityUri = communityUri;
             return this;
         }
 
-        public Builder setApiProxyHost(String apiProxyHost) {
-            this.apiProxyHost = apiProxyHost;
+        /**
+         * Set default API Gateway host address.
+         *
+         * @param apiGatewayUri the API Gateway host address.
+         * @return this builder.
+         */
+        @NonNull
+        public Builder setApiGatewayUri(String apiGatewayUri) {
+            this.apiGatewayUri = apiGatewayUri;
             return this;
         }
 
-        public Builder setClientAppName(String clientAppName) {
-            this.clientAppName = clientAppName;
+        /**
+         * Set the API gateways host address.
+         *
+         * @param apiProxyHost The API gateways host address.
+         * @return this builder.
+         * @deprecated Use {@link #getApiGatewayHost()} instead.
+         */
+        public Builder setApiProxyHost(@NonNull String apiProxyHost) {
+            this.apiGatewayUri = apiProxyHost;
             return this;
         }
 
-        public LiAppCredentials build() throws MalformedURLException {
-            return new LiAppCredentials(clientKey, clientSecret, communityUri, tenantId, apiProxyHost, clientAppName);
+        /**
+         * Set the client name.
+         *
+         * @param clientAppName The client name to set
+         * @return this builder
+         * @deprecated Use {@link #setClientName(String)}
+         */
+        public Builder setClientAppName(@NonNull String clientAppName) {
+            this.clientName = clientAppName;
+            return this;
+        }
+
+        /**
+         * Build and return a new instance of {@link LiAppCredentials}.
+         *
+         * @return a new instance of {@link LiAppCredentials}.
+         */
+        @NonNull
+        public LiAppCredentials build() {
+            return new LiAppCredentials(clientName, clientKey, clientSecret, tenantId, communityUri, apiGatewayUri);
         }
     }
 }

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/auth/LiAppCredentials.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/auth/LiAppCredentials.java
@@ -55,7 +55,7 @@ public final class LiAppCredentials {
     private final String ssoAuthorizeUri;
 
     /**
-     * Default public constructor for Lia SDK Credentials.
+     * Default private constructor for Lia SDK Credentials.
      *
      * @param clientName     The client name.
      * @param clientKey      The client Id.

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/auth/LiAppCredentials.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/auth/LiAppCredentials.java
@@ -23,7 +23,10 @@ import lithium.community.android.sdk.utils.LiCoreSDKUtils;
 import lithium.community.android.sdk.utils.LiUriUtils;
 
 /**
- * The credentials for initializing the LIA SDK.
+ * The credentials for initializing the LIA SDK Manager. The client name, client Id, client secret,
+ * and tenant Id can be found in the Community Admin page; under the System category choose Api Apps.
+ * Make sure that the credentials are for Android. The community URL is the public domain where your
+ * community is hosted. The default API gateway host is "api.lithium.com".
  */
 public final class LiAppCredentials {
 

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/auth/LiAppCredentials.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/auth/LiAppCredentials.java
@@ -164,20 +164,19 @@ public final class LiAppCredentials {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
+        if (this == o) {
+            return true;
+        }
+
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
 
         LiAppCredentials that = (LiAppCredentials) o;
 
-        if (!clientName.equals(that.clientName)) return false;
-        if (!tenantId.equals(that.tenantId)) return false;
-        if (!clientKey.equals(that.clientKey)) return false;
-        if (!clientSecret.equals(that.clientSecret)) return false;
-        if (!communityUri.equals(that.communityUri)) return false;
-        if (!apiGatewayHost.equals(that.apiGatewayHost)) return false;
-        if (!authorizeUri.equals(that.authorizeUri)) return false;
-        if (!redirectUri.equals(that.redirectUri)) return false;
-        return ssoAuthorizeUri.equals(that.ssoAuthorizeUri);
+        return clientName.equals(that.clientName) && tenantId.equals(that.tenantId) && clientKey.equals(that.clientKey)
+                && clientSecret.equals(that.clientSecret) && communityUri.equals(that.communityUri) && apiGatewayHost.equals(that.apiGatewayHost)
+                && authorizeUri.equals(that.authorizeUri) && redirectUri.equals(that.redirectUri) && ssoAuthorizeUri.equals(that.ssoAuthorizeUri);
     }
 
     @Override

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/auth/LiAppCredentials.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/auth/LiAppCredentials.java
@@ -21,6 +21,7 @@ import android.support.annotation.NonNull;
 
 import lithium.community.android.sdk.utils.LiCoreSDKUtils;
 import lithium.community.android.sdk.utils.LiUriUtils;
+import lithium.community.android.sdk.utils.MessageConstants;
 
 /**
  * The credentials for initializing the LIA SDK Manager. The client name, client Id, client secret,
@@ -76,18 +77,18 @@ public final class LiAppCredentials {
      * @param clientKey      The client Id.
      * @param clientSecret   The client secret.
      * @param tenantId       tenant ID of the community.
-     * @param communityURL   The LIA community's URL.
-     * @param apiGatewayHost API gateway host.
+     * @param communityURL   The LIA community's URL. (scheme + host)
+     * @param apiGatewayHost API gateway host. (host)
      */
     public LiAppCredentials(@NonNull String clientName, @NonNull String clientKey, @NonNull String clientSecret,
                             @NonNull String tenantId, @NonNull String communityURL, @NonNull String apiGatewayHost) {
-        this.clientName = LiCoreSDKUtils.checkNullOrNotEmpty(clientName, "clientName was empty");
-        this.clientKey = LiCoreSDKUtils.checkNullOrNotEmpty(clientKey, "clientKey was empty");
-        this.clientSecret = LiCoreSDKUtils.checkNullOrNotEmpty(clientSecret, "clientSecret was empty");
-        this.tenantId = LiCoreSDKUtils.checkNullOrNotEmpty(tenantId, "tenantId was empty");
+        this.clientName = LiCoreSDKUtils.checkNullOrNotEmpty(clientName, MessageConstants.wasEmpty("clientName"));
+        this.clientKey = LiCoreSDKUtils.checkNullOrNotEmpty(clientKey, MessageConstants.wasEmpty("clientKey"));
+        this.clientSecret = LiCoreSDKUtils.checkNullOrNotEmpty(clientSecret, MessageConstants.wasEmpty("clientSecret"));
+        this.tenantId = LiCoreSDKUtils.checkNullOrNotEmpty(tenantId, MessageConstants.wasEmpty("tenantId"));
 
-        this.communityUri = Uri.parse(LiCoreSDKUtils.checkNullOrNotEmpty(communityURL, "communityURL was empty"));
-        this.apiGatewayHost = Uri.parse(LiCoreSDKUtils.checkNullOrNotEmpty(apiGatewayHost, "apiGatewayHost was empty"));
+        this.communityUri = Uri.parse(LiCoreSDKUtils.checkNullOrNotEmpty(communityURL, MessageConstants.wasEmpty("communityURL")));
+        this.apiGatewayHost = Uri.parse(LiCoreSDKUtils.checkNullOrNotEmpty(apiGatewayHost, MessageConstants.wasEmpty("apiGatewayHost")));
 
         this.redirectUri = buildRedirectUri(communityUri);
         this.ssoAuthorizeUri = communityURL + SSO_AUTH_END_POINT;

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/auth/LiAppCredentials.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/auth/LiAppCredentials.java
@@ -27,6 +27,18 @@ import lithium.community.android.sdk.utils.LiUriUtils;
  */
 public final class LiAppCredentials {
 
+    /**
+     * The API end point for authorizing SSO login.
+     */
+    @NonNull
+    private static final String SSO_AUTH_END_POINT = "api/2.0/auth/authorize";
+
+    /**
+     * The API end point for authorizing login using OAuth 2.0.
+     */
+    @NonNull
+    private static final String OAUTH_END_POINT = "auth/oauth2/authorize";
+
     @NonNull
     private final String clientName;
 
@@ -75,8 +87,8 @@ public final class LiAppCredentials {
         this.apiGatewayHost = Uri.parse(LiCoreSDKUtils.checkNullOrNotEmpty(apiGatewayHost, "apiGatewayHost was empty"));
 
         this.redirectUri = buildRedirectUri(communityUri);
-        this.ssoAuthorizeUri = communityURL + "api/2.0/auth/authorize";
-        this.authorizeUri = this.communityUri.buildUpon().path("auth/oauth2/authorize").build();
+        this.ssoAuthorizeUri = communityURL + SSO_AUTH_END_POINT;
+        this.authorizeUri = this.communityUri.buildUpon().path(OAUTH_END_POINT).build();
     }
 
     private static String buildRedirectUri(Uri communityUri) {

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/auth/LiAppCredentials.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/auth/LiAppCredentials.java
@@ -262,7 +262,7 @@ public final class LiAppCredentials {
          * @return this builder.
          */
         @NonNull
-        public Builder setApiGatewayUri(String apiGatewayUri) {
+        public Builder setApiGatewayUri(@NonNull String apiGatewayUri) {
             this.apiGatewayUri = apiGatewayUri;
             return this;
         }

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/auth/LiAuthRequestStore.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/auth/LiAuthRequestStore.java
@@ -24,7 +24,8 @@ import java.util.Map;
 import static lithium.community.android.sdk.auth.LiAuthConstants.LOG_TAG;
 
 class LiAuthRequestStore {
-    private static LiAuthRequestStore INSTANCE;
+
+    private static LiAuthRequestStore instance;
 
     private Map<String, LiSSOAuthorizationRequest> mLiRequests = new HashMap<>();
 
@@ -32,10 +33,10 @@ class LiAuthRequestStore {
     }
 
     public static synchronized LiAuthRequestStore getInstance() {
-        if (INSTANCE == null) {
-            INSTANCE = new LiAuthRequestStore();
+        if (instance == null) {
+            instance = new LiAuthRequestStore();
         }
-        return INSTANCE;
+        return instance;
     }
 
     /**

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/exception/LiExceptionInInitializerError.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/exception/LiExceptionInInitializerError.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2018 Lithium Technologies Pvt Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package lithium.community.android.sdk.exception;
+
+import android.support.annotation.NonNull;
+
+/**
+ * This exception is sugar for {@link ExceptionInInitializerError} exceptions
+ * which may be thrown by static component initializer in the SDK.
+ *
+ * @author adityasharat
+ */
+public class LiExceptionInInitializerError extends ExceptionInInitializerError {
+
+    @NonNull
+    private final String name;
+
+    @NonNull
+    private final String message;
+
+    /**
+     * Default public constructor.
+     *
+     * @param cause The error or exceptions because of which the component could not be initialized.
+     * @param name  The name of the component which could not be initialized.
+     */
+    public LiExceptionInInitializerError(@NonNull Throwable cause, @NonNull String name) {
+        super(cause);
+        this.name = name;
+        this.message = String.format("%s failed to initialize.", this.name);
+    }
+
+    /**
+     * The pretty message for the exception.
+     *
+     * @return the exception message.
+     */
+    @NonNull
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    /**
+     * The name of the component which failed to initialize.
+     *
+     * @return The name of the component which failed to initialize.
+     */
+    @NonNull
+    public String getName() {
+        return name;
+    }
+}

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/exception/LiInitializationException.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/exception/LiInitializationException.java
@@ -17,42 +17,39 @@
 package lithium.community.android.sdk.exception;
 
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 /**
- * This exception is sugar for {@link ExceptionInInitializerError} exceptions
- * which may be thrown by static component initializer in the SDK.
+ * This exception in line with {@link ExceptionInInitializerError} but
+ * is not a type of runtime exception and is required to be caught
+ * which may be thrown by component initializer in the SDK.
  *
  * @author adityasharat
  */
-public class LiExceptionInInitializerError extends ExceptionInInitializerError {
+public class LiInitializationException extends Exception {
 
     @NonNull
     private final String name;
 
-    @NonNull
-    private final String message;
-
     /**
      * Default public constructor.
      *
-     * @param cause The error or exceptions because of which the component could not be initialized.
      * @param name  The name of the component which could not be initialized.
+     * @param cause The error or exceptions because of which the component could not be initialized.
      */
-    public LiExceptionInInitializerError(@NonNull Throwable cause, @NonNull String name) {
-        super(cause);
+    public LiInitializationException(@NonNull String name, @Nullable Throwable cause) {
+        super(String.format("%s failed to initialize.", name), cause);
         this.name = name;
-        this.message = String.format("%s failed to initialize.", this.name);
     }
 
     /**
-     * The pretty message for the exception.
+     * Overridden public constructor to be used if the cause of the initialization
+     * exceptions is not known.
      *
-     * @return the exception message.
+     * @param name The name of the component which could not be initialized.
      */
-    @NonNull
-    @Override
-    public String getMessage() {
-        return message;
+    public LiInitializationException(@NonNull String name) {
+        this(name, null);
     }
 
     /**

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiAuthManager.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiAuthManager.java
@@ -60,7 +60,7 @@ class LiAuthManager {
     private LiAuthState liAuthState;
     private LiDeviceTokenProvider liDeviceTokenProvider;
 
-    LiAuthManager(Context context, LiAppCredentials liAppCredentials) {
+    LiAuthManager(@NonNull Context context, @NonNull LiAppCredentials liAppCredentials) {
         this.liAuthState = restoreAuthState(context);
         this.liAppCredentials = liAppCredentials;
     }
@@ -155,7 +155,7 @@ class LiAuthManager {
      * @throws URISyntaxException
      */
     public void initLoginFlow(Context context, String ssoToken,
-            LiDeviceTokenProvider liDeviceTokenProvider) throws URISyntaxException {
+                              LiDeviceTokenProvider liDeviceTokenProvider) throws URISyntaxException {
         this.liDeviceTokenProvider = liDeviceTokenProvider;
         if (!isUserLoggedIn()) {
             new LiAuthServiceImpl(context).startLoginFlow(ssoToken);
@@ -310,7 +310,7 @@ class LiAuthManager {
      * @throws LiRestResponseException {@link LiRestResponseException}
      */
     public void fetchFreshAccessToken(final Context context,
-            final LiAuthService.FreshTokenCallBack mFreshTokenCallBack)
+                                      final LiAuthService.FreshTokenCallBack mFreshTokenCallBack)
             throws URISyntaxException, LiRestResponseException {
 
         new LiAuthServiceImpl(context).performRefreshTokenRequest(new LiAuthService.LiTokenResponseCallback() {

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiSDKManager.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiSDKManager.java
@@ -113,6 +113,7 @@ public final class LiSDKManager extends LiAuthManager {
 
         LiCoreSDKUtils.checkNotNull(context, "context was null");
         LiCoreSDKUtils.checkNotNull(credentials, "credentials was null");
+
         if (isInitialized.compareAndSet(false, true)) {
             if (LiDefaultQueryHelper.initHelper(context) == null) {
                 return null;
@@ -123,8 +124,6 @@ public final class LiSDKManager extends LiAuthManager {
             instance = new LiSDKManager(context, credentials);
         }
 
-        LiCoreSDKUtils.checkNotNull(context, "context was null");
-        LiCoreSDKUtils.checkNotNull(credentials, "credentials was null");
         if (getInstance() != null && getInstance().getFromSecuredPreferences(context, LI_VISITOR_ID) == null) {
             //Generate a visitor ID and save it in secure preferences
             getInstance().putInSecuredPreferences(context, LI_VISITOR_ID, LiCoreSDKUtils.getRandomHexString());

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiSDKManager.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiSDKManager.java
@@ -44,6 +44,7 @@ import lithium.community.android.sdk.rest.LiGetClientResponse;
 import lithium.community.android.sdk.utils.LiCoreSDKConstants;
 import lithium.community.android.sdk.utils.LiCoreSDKUtils;
 import lithium.community.android.sdk.utils.LiUUIDUtils;
+import lithium.community.android.sdk.utils.MessageConstants;
 
 import static lithium.community.android.sdk.auth.LiAuthConstants.LOG_TAG;
 import static lithium.community.android.sdk.utils.LiCoreSDKConstants.LI_DEFAULT_SDK_SETTINGS;
@@ -79,8 +80,8 @@ public final class LiSDKManager extends LiAuthManager {
      */
     public static synchronized void initialize(@NonNull final Context context, @NonNull final LiAppCredentials credentials) throws LiInitializationException {
 
-        LiCoreSDKUtils.checkNotNull(context, "context was null");
-        LiCoreSDKUtils.checkNotNull(credentials, "credentials was null");
+        LiCoreSDKUtils.checkNotNull(context, MessageConstants.wasNull("context"));
+        LiCoreSDKUtils.checkNotNull(credentials, MessageConstants.wasNull("credentials"));
 
         if (isInitialized.compareAndSet(false, true)) {
             if (LiDefaultQueryHelper.initHelper(context) == null) {
@@ -106,8 +107,8 @@ public final class LiSDKManager extends LiAuthManager {
     @Nullable
     public static synchronized LiSDKManager init(@NonNull final Context context, @NonNull final LiAppCredentials credentials) throws URISyntaxException {
 
-        LiCoreSDKUtils.checkNotNull(context, "context was null");
-        LiCoreSDKUtils.checkNotNull(credentials, "credentials was null");
+        LiCoreSDKUtils.checkNotNull(context, MessageConstants.wasNull("context"));
+        LiCoreSDKUtils.checkNotNull(credentials, MessageConstants.wasNull("credentials"));
 
         if (isInitialized.compareAndSet(false, true)) {
             if (LiDefaultQueryHelper.initHelper(context) == null) {
@@ -168,31 +169,24 @@ public final class LiSDKManager extends LiAuthManager {
         if (instance.isUserLoggedIn()) {
             try {
                 String clientId = LiUUIDUtils.toUUID(liAppCredentials.getClientKey().getBytes()).toString();
-                LiClientRequestParams liClientRequestParams
-                        = new LiClientRequestParams.LiSdkSettingsClientRequestParams(context, clientId);
+                LiClientRequestParams liClientRequestParams = new LiClientRequestParams.LiSdkSettingsClientRequestParams(context, clientId);
                 LiClientManager.getSdkSettingsClient(liClientRequestParams).processAsync(
                         new LiAsyncRequestCallback<LiGetClientResponse>() {
 
                             @Override
-                            public void onSuccess(LiBaseRestRequest request,
-                                                  LiGetClientResponse response)
+                            public void onSuccess(LiBaseRestRequest request, LiGetClientResponse response)
                                     throws LiRestResponseException {
                                 if (response != null && response.getHttpCode() == LiCoreSDKConstants.HTTP_CODE_SUCCESSFUL) {
                                     Gson gson = new Gson();
                                     JsonObject responseJsonObject = response.getJsonObject();
                                     if (responseJsonObject.has("data")) {
-                                        JsonObject dataObj = responseJsonObject.get("data")
-                                                .getAsJsonObject();
+                                        JsonObject dataObj = responseJsonObject.get("data").getAsJsonObject();
                                         if (dataObj.has("items")) {
                                             JsonArray items = dataObj.get("items").getAsJsonArray();
                                             if (!items.isJsonNull() && items.size() > 0) {
-                                                LiAppSdkSettings liAppSdkSettings =
-                                                        gson.fromJson(items.get(0), LiAppSdkSettings.class);
+                                                LiAppSdkSettings liAppSdkSettings = gson.fromJson(items.get(0), LiAppSdkSettings.class);
                                                 if (liAppSdkSettings != null) {
-                                                    getInstance().putInSecuredPreferences(
-                                                            context,
-                                                            LI_DEFAULT_SDK_SETTINGS,
-                                                            liAppSdkSettings.getAdditionalInformation());
+                                                    putInSecuredPreferences(context, LI_DEFAULT_SDK_SETTINGS, liAppSdkSettings.getAdditionalInformation());
                                                 }
                                             }
                                         }
@@ -204,8 +198,7 @@ public final class LiSDKManager extends LiAuthManager {
 
                             @Override
                             public void onError(Exception exception) {
-                                Log.e(LiCoreSDKConstants.LI_LOG_TAG,
-                                        "Error getting SDK settings: " + exception.getMessage());
+                                Log.e(LiCoreSDKConstants.LI_LOG_TAG, "Error getting SDK settings: " + exception.getMessage());
                             }
                         });
             } catch (LiRestResponseException e) {
@@ -213,17 +206,13 @@ public final class LiSDKManager extends LiAuthManager {
             }
             //get logged in user details
             try {
-                LiClientRequestParams liClientRequestParams
-                        = new LiClientRequestParams.LiUserDetailsClientRequestParams(context, "self");
+                LiClientRequestParams liClientRequestParams = new LiClientRequestParams.LiUserDetailsClientRequestParams(context, "self");
                 LiClientManager.getUserDetailsClient(liClientRequestParams)
                         .processAsync(new LiAsyncRequestCallback<LiGetClientResponse>() {
                             @Override
-                            public void onSuccess(LiBaseRestRequest request, LiGetClientResponse
-                                    liClientResponse) throws LiRestResponseException {
-                                if (liClientResponse != null
-                                        && liClientResponse.getHttpCode() == LiCoreSDKConstants.HTTP_CODE_SUCCESSFUL
-                                        && liClientResponse.getResponse() != null
-                                        && !liClientResponse.getResponse().isEmpty()) {
+                            public void onSuccess(LiBaseRestRequest request, LiGetClientResponse liClientResponse) throws LiRestResponseException {
+                                if (liClientResponse != null && liClientResponse.getHttpCode() == LiCoreSDKConstants.HTTP_CODE_SUCCESSFUL
+                                        && liClientResponse.getResponse() != null && !liClientResponse.getResponse().isEmpty()) {
                                     LiUser user = (LiUser) liClientResponse.getResponse().get(0).getModel();
                                     instance.setLoggedInUser(context, user);
                                 } else {

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiSDKManager.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiSDKManager.java
@@ -66,7 +66,7 @@ public final class LiSDKManager extends LiAuthManager {
      * @param context     The Android context
      * @param credentials The credentials to be used to authenticate the SDK.
      */
-    private LiSDKManager(Context context, LiAppCredentials credentials) {
+    private LiSDKManager(@NonNull Context context, @NonNull LiAppCredentials credentials) {
         super(context, credentials);
     }
 
@@ -92,8 +92,6 @@ public final class LiSDKManager extends LiAuthManager {
             instance = new LiSDKManager(context, credentials);
         }
 
-        LiCoreSDKUtils.checkNotNull(context, "context was null");
-        LiCoreSDKUtils.checkNotNull(credentials, "credentials was null");
         if (getInstance() != null && getInstance().getFromSecuredPreferences(context, LI_VISITOR_ID) == null) {
 
             // Generate a visitor ID and save it in secure preferences

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiSDKManager.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiSDKManager.java
@@ -91,12 +91,7 @@ public final class LiSDKManager extends LiAuthManager {
             }
             instance = new LiSDKManager(context, credentials);
         }
-
-        if (getInstance() != null && getInstance().getFromSecuredPreferences(context, LI_VISITOR_ID) == null) {
-
-            // Generate a visitor ID and save it in secure preferences
-            getInstance().putInSecuredPreferences(context, LI_VISITOR_ID, LiCoreSDKUtils.getRandomHexString());
-        }
+        updatePreferences(context);
     }
 
     /**
@@ -123,12 +118,7 @@ public final class LiSDKManager extends LiAuthManager {
             }
             instance = new LiSDKManager(context, credentials);
         }
-
-        if (getInstance() != null && getInstance().getFromSecuredPreferences(context, LI_VISITOR_ID) == null) {
-            //Generate a visitor ID and save it in secure preferences
-            getInstance().putInSecuredPreferences(context, LI_VISITOR_ID, LiCoreSDKUtils.getRandomHexString());
-        }
-
+        updatePreferences(context);
         return instance;
     }
 
@@ -160,6 +150,12 @@ public final class LiSDKManager extends LiAuthManager {
     @Nullable
     public static LiSDKManager getInstance() {
         return instance;
+    }
+
+    private static void updatePreferences(@NonNull Context context) {
+        if (getInstance() != null && getInstance().getFromSecuredPreferences(context, LI_VISITOR_ID) == null) {
+            getInstance().putInSecuredPreferences(context, LI_VISITOR_ID, LiCoreSDKUtils.getRandomHexString()); // generate a visitor ID and save it
+        }
     }
 
     /**

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiSecuredPrefManager.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiSecuredPrefManager.java
@@ -43,8 +43,8 @@ class LiSecuredPrefManager {
     private static final String ENCRYPTION_ALGORITHM = "AES";
     private static final int ENCRYPTION_LENGTH = 16;
 
-    private static AtomicBoolean IS_INITIALIZED = new AtomicBoolean(false);
-    private static LiSecuredPrefManager INSTANCE;
+    private static AtomicBoolean isInitialized = new AtomicBoolean(false);
+    private static LiSecuredPrefManager instance;
 
     private MessageDigest sha;
     private Key aesKey;
@@ -61,11 +61,11 @@ class LiSecuredPrefManager {
      * Instance of this.
      */
     public static LiSecuredPrefManager getInstance() {
-        if (INSTANCE == null) {
+        if (instance == null) {
             Log.e(LI_LOG_TAG, "LiSecuredPrefManager not intialized. Call init method first");
             return null;
         }
-        return INSTANCE;
+        return instance;
     }
 
     private static String encode(byte[] input) {
@@ -77,14 +77,14 @@ class LiSecuredPrefManager {
     }
 
     public static synchronized LiSecuredPrefManager init(Context context) {
-        if (IS_INITIALIZED.compareAndSet(false, true)) {
+        if (isInitialized.compareAndSet(false, true)) {
             try {
-                INSTANCE = new LiSecuredPrefManager(context);
+                instance = new LiSecuredPrefManager(context);
             } catch (NoSuchAlgorithmException e) {
                 Log.e(LiCoreSDKConstants.LI_LOG_TAG, e.getMessage());
             }
         }
-        return INSTANCE;
+        return instance;
     }
 
     public String encrypt(String str) throws Exception {
@@ -112,31 +112,31 @@ class LiSecuredPrefManager {
 
     public void remove(Context context, String key) {
         try {
-            INSTANCE.getSecuredPreferences(context).edit().remove(
-                    INSTANCE.encrypt(key)).apply();
+            instance.getSecuredPreferences(context).edit().remove(
+                    instance.encrypt(key)).apply();
         } catch (Exception e) {
             Log.e(LI_LOG_TAG, "Encryption error, " + e.getMessage());
-            INSTANCE.getSecuredPreferences(context).edit().remove(key).apply();
+            instance.getSecuredPreferences(context).edit().remove(key).apply();
         }
     }
 
     public void putString(Context context, String key, String value) {
         try {
-            INSTANCE.getSecuredPreferences(context).edit().putString(
-                    INSTANCE.encrypt(key),
-                    INSTANCE.encrypt(value)).apply();
+            instance.getSecuredPreferences(context).edit().putString(
+                    instance.encrypt(key),
+                    instance.encrypt(value)).apply();
         } catch (Exception e) {
             Log.e(LI_LOG_TAG, "Encryption error, " + e.getMessage());
-            INSTANCE.getSecuredPreferences(context).edit().putString(key, value).apply();
+            instance.getSecuredPreferences(context).edit().putString(key, value).apply();
         }
     }
 
     public String getString(Context context, String key) {
         //get secured preferences and check key has any value there
-        SharedPreferences securedPreferences = INSTANCE.getSecuredPreferences(context);
+        SharedPreferences securedPreferences = instance.getSecuredPreferences(context);
         String value;
         try {
-            value = INSTANCE.decrypt(securedPreferences.getString(INSTANCE.encrypt(key), null));
+            value = instance.decrypt(securedPreferences.getString(instance.encrypt(key), null));
             if (value == null) {
                 //if not present then check in old unencrypted preferences and then move it new encrypted preferences
                 // file

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/model/LiBaseModelImpl.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/model/LiBaseModelImpl.java
@@ -157,17 +157,9 @@ public class LiBaseModelImpl implements LiBaseModel {
     }
 
     public static class LiDate extends LiBaseModelImpl {
-        private static SimpleDateFormat LIA_DATE_TIME_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS");
+        private static final SimpleDateFormat LIA_DATE_TIME_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS");
 
         private LiDateInstant value;
-
-        public void setValue(@NonNull String valueStr) {
-            setValue(new LiDateInstant());
-        }
-
-        public void setValue(LiDateInstant value) {
-            this.value = value;
-        }
 
         public String getValueAsLithiumFormattedDate() {
             return LIA_DATE_TIME_FORMAT.format(value);
@@ -176,12 +168,32 @@ public class LiBaseModelImpl implements LiBaseModel {
         public LiDateInstant getValue() {
             return value;
         }
+
+        public void setValue(@NonNull String valueStr) {
+            setValue(new LiDateInstant());
+        }
+
+        public void setValue(LiDateInstant value) {
+            this.value = value;
+        }
     }
 
     public static class LiDateInstant extends LiBaseModelImpl {
-        private static SimpleDateFormat LIA_DATE_TIME_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+        private static final SimpleDateFormat LIA_DATE_TIME_FORMAT = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
 
         private long value;
+
+        public String getValueAsLithiumFormattedDate() {
+            return LIA_DATE_TIME_FORMAT.format(value);
+        }
+
+        public long getValue() {
+            return this.value;
+        }
+
+        public void setValue(long value) {
+            this.value = value;
+        }
 
         public void setValue(@NonNull String valueStr) {
             LIA_DATE_TIME_FORMAT.setTimeZone(TimeZone.getDefault());
@@ -193,19 +205,6 @@ public class LiBaseModelImpl implements LiBaseModel {
             }
             setValue(dt.getTime());
         }
-
-        public void setValue(long value) {
-            this.value = value;
-        }
-
-        public String getValueAsLithiumFormattedDate() {
-            return LIA_DATE_TIME_FORMAT.format(value);
-        }
-
-        public long getValue() {
-            return this.value;
-        }
-
     }
 
     public static class LiPrivacyLevelValue extends LiBaseModelImpl {

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/queryutil/LiDefaultQueryHelper.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/queryutil/LiDefaultQueryHelper.java
@@ -33,7 +33,7 @@ import lithium.community.android.sdk.utils.LiCoreSDKUtils;
 
 public class LiDefaultQueryHelper {
 
-    private static LiDefaultQueryHelper INSTANCE;
+    private static LiDefaultQueryHelper instance;
     private JsonObject defaultSetting;
 
     /**
@@ -52,20 +52,20 @@ public class LiDefaultQueryHelper {
      * @return Singleton instance of this class.
      */
     public static synchronized LiDefaultQueryHelper initHelper(Context context) {
-        if (INSTANCE == null) {
-            INSTANCE = new LiDefaultQueryHelper(context);
+        if (instance == null) {
+            instance = new LiDefaultQueryHelper(context);
         }
-        return INSTANCE;
+        return instance;
     }
 
     /**
      * @return Instance of this class.
      */
     public static LiDefaultQueryHelper getInstance() {
-        if (INSTANCE == null) {
+        if (instance == null) {
             throw new NoSuchPropertyException("Helper not intialized. Call init method first");
         }
-        return INSTANCE;
+        return instance;
     }
 
     /**

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/queryutil/LiQueryBuilder.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/queryutil/LiQueryBuilder.java
@@ -45,7 +45,7 @@ public class LiQueryBuilder {
     private static final String ORDER_BY = "ORDER BY";
     private static final String LIMIT = "LIMIT";
 
-    private static volatile LiQuerySetting LI_QUERY_SETTING;
+    private static volatile LiQuerySetting liQuerySetting;
 
     private static JsonObject getDefault(String client) {
         JsonObject jsonObject = LiDefaultQueryHelper.getInstance().getDefaultSetting();
@@ -125,11 +125,11 @@ public class LiQueryBuilder {
         JsonObject clientSettings = getClientJsonSetting(client, context);
         Gson gson = new Gson();
         try {
-            LI_QUERY_SETTING = gson.fromJson(clientSettings, LiQuerySetting.class);
+            liQuerySetting = gson.fromJson(clientSettings, LiQuerySetting.class);
         } catch (Exception exception) {
             Log.e("LiQueryBuilder", "Error parsing client setting json: " + clientSettings.toString());
         }
-        return LI_QUERY_SETTING;
+        return liQuerySetting;
     }
 
     /**

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/rest/LiRestv2Client.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/rest/LiRestv2Client.java
@@ -93,7 +93,8 @@ public class LiRestv2Client extends LiRestClient {
     @Override
     public void processAsync(@NonNull LiBaseRestRequest baseRestRequest, @NonNull LiAsyncRequestCallback callBack) {
 
-        LiCoreSDKUtils.checkNotNull(baseRestRequest, callBack);
+        LiCoreSDKUtils.checkNotNull(baseRestRequest, "baseRestRequest was null");
+        LiCoreSDKUtils.checkNotNull(callBack, "callback was null");
 
         if (baseRestRequest instanceof LiBaseRestRequest == false) {
             Log.e(LOG_TAG, "Invalid rest v2 request");
@@ -119,10 +120,11 @@ public class LiRestv2Client extends LiRestClient {
      * @param imageName       Name of the image file.
      * @param requestBody     request body for post call to upload image.
      */
-    public void uploadProcessAsync(@NonNull LiBaseRestRequest baseRestRequest,
-            @NonNull LiAsyncRequestCallback callBack, String imagePath, String imageName, String requestBody) {
+    public void uploadProcessAsync(@NonNull LiBaseRestRequest baseRestRequest, @NonNull LiAsyncRequestCallback callBack, String imagePath,
+                                   String imageName, String requestBody) {
 
-        LiCoreSDKUtils.checkNotNull(baseRestRequest, callBack);
+        LiCoreSDKUtils.checkNotNull(baseRestRequest, "baseRestRequest was null");
+        LiCoreSDKUtils.checkNotNull(callBack, "callback was null");
 
         if (baseRestRequest instanceof LiBaseRestRequest == false) {
             Log.e(LOG_TAG, "Invalid rest v2 request");

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/rest/LiRestv2Client.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/rest/LiRestv2Client.java
@@ -26,6 +26,7 @@ import java.io.IOException;
 
 import lithium.community.android.sdk.exception.LiRestResponseException;
 import lithium.community.android.sdk.utils.LiCoreSDKUtils;
+import lithium.community.android.sdk.utils.MessageConstants;
 
 /**
  * Rest v2 client for community. Always expects LiQL queries in requests
@@ -55,10 +56,10 @@ public class LiRestv2Client extends LiRestClient {
      */
     @Override
     public LiBaseResponse processSync(@NonNull LiBaseRestRequest baseRestRequest) throws LiRestResponseException {
-
-        LiCoreSDKUtils.checkNotNull(baseRestRequest);
+        LiCoreSDKUtils.checkNotNull(baseRestRequest, MessageConstants.wasNull("baseRestRequest"));
         LiRestV2Request restV2Request = getLiRestV2Request(baseRestRequest);
         LiBaseResponse response = super.processSync(restV2Request);
+
         return validateResponse(response);
     }
 
@@ -70,18 +71,14 @@ public class LiRestv2Client extends LiRestClient {
      * @throws LiRestResponseException
      */
     @NonNull
-    private LiRestV2Request getLiRestV2Request(
-            @NonNull LiBaseRestRequest baseRestRequest) throws LiRestResponseException {
-        LiCoreSDKUtils.checkNotNull(baseRestRequest);
-
-        if (baseRestRequest instanceof LiBaseRestRequest == false) {
+    private LiRestV2Request getLiRestV2Request(@NonNull LiBaseRestRequest baseRestRequest) throws LiRestResponseException {
+        LiCoreSDKUtils.checkNotNull(baseRestRequest, MessageConstants.wasNull("baseRestRequest"));
+        if (!(baseRestRequest instanceof LiBaseRestRequest)) {
             Log.e(LOG_TAG, "Invalid rest v2 request");
-            throw LiRestResponseException.illegalArgumentError(
-                    "Rest v2 request should pass a liql query request parameter");
+            throw LiRestResponseException.illegalArgumentError("Rest v2 request should pass a liql query request parameter");
         }
 
-        LiRestV2Request restV2Request = (LiRestV2Request) baseRestRequest;
-        return restV2Request;
+        return (LiRestV2Request) baseRestRequest;
     }
 
     /**
@@ -93,13 +90,12 @@ public class LiRestv2Client extends LiRestClient {
     @Override
     public void processAsync(@NonNull LiBaseRestRequest baseRestRequest, @NonNull LiAsyncRequestCallback callBack) {
 
-        LiCoreSDKUtils.checkNotNull(baseRestRequest, "baseRestRequest was null");
-        LiCoreSDKUtils.checkNotNull(callBack, "callback was null");
+        LiCoreSDKUtils.checkNotNull(baseRestRequest, MessageConstants.wasNull("baseRestRequest"));
+        LiCoreSDKUtils.checkNotNull(callBack, MessageConstants.wasNull("callback"));
 
-        if (baseRestRequest instanceof LiBaseRestRequest == false) {
+        if (!(baseRestRequest instanceof LiBaseRestRequest)) {
             Log.e(LOG_TAG, "Invalid rest v2 request");
-            callBack.onError(LiRestResponseException.illegalArgumentError(
-                    "Rest v2 request should pass a liql query request parameter"));
+            callBack.onError(LiRestResponseException.illegalArgumentError("Rest v2 request should pass a liql query request parameter"));
         }
 
         LiRestV2Request restV2Request = null;
@@ -123,13 +119,12 @@ public class LiRestv2Client extends LiRestClient {
     public void uploadProcessAsync(@NonNull LiBaseRestRequest baseRestRequest, @NonNull LiAsyncRequestCallback callBack, String imagePath,
                                    String imageName, String requestBody) {
 
-        LiCoreSDKUtils.checkNotNull(baseRestRequest, "baseRestRequest was null");
-        LiCoreSDKUtils.checkNotNull(callBack, "callback was null");
+        LiCoreSDKUtils.checkNotNull(baseRestRequest, MessageConstants.wasNull("baseRestRequest"));
+        LiCoreSDKUtils.checkNotNull(callBack, MessageConstants.wasNull("callBack"));
 
-        if (baseRestRequest instanceof LiBaseRestRequest == false) {
+        if (!(baseRestRequest instanceof LiBaseRestRequest)) {
             Log.e(LOG_TAG, "Invalid rest v2 request");
-            callBack.onError(LiRestResponseException.illegalArgumentError(
-                    "Rest v2 request should pass a liql query request parameter"));
+            callBack.onError(LiRestResponseException.illegalArgumentError("Rest v2 request should pass a liql query request parameter"));
         }
 
         LiRestV2Request restV2Request = null;
@@ -140,7 +135,6 @@ public class LiRestv2Client extends LiRestClient {
         }
 
         super.uploadImageProcessAsync(baseRestRequest, callBack, imagePath, imageName, requestBody);
-
     }
 
     /**

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/utils/LiCoreSDKUtils.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/utils/LiCoreSDKUtils.java
@@ -59,20 +59,20 @@ import okhttp3.Request;
  */
 public class LiCoreSDKUtils {
     private static final int INITIAL_READ_BUFFER_SIZE = 1024;
-    private static final ThreadLocal<SecureRandom> randTl = new ThreadLocal<SecureRandom>() {
+    private static final ThreadLocal<SecureRandom> RAND_TL = new ThreadLocal<SecureRandom>() {
         @Override
         protected SecureRandom initialValue() {
             return new SecureRandom();
         }
     };
-    private static char[] HEX_CHAR = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
+    private static final char[] HEX_CHAR = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D', 'E', 'F'};
 
     private LiCoreSDKUtils() {
     }
 
 
     public static String getRandomHexString() {
-        return toHexString(getRandomBytes(randTl.get(), 128));
+        return toHexString(getRandomBytes(RAND_TL.get(), 128));
     }
 
     /**

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/utils/LiCoreSDKUtils.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/utils/LiCoreSDKUtils.java
@@ -124,22 +124,7 @@ public class LiCoreSDKUtils {
      * @throws IllegalArgumentException if the argument value is {@code null}.
      */
     public static <ArgT> ArgT checkNotNull(ArgT argValue) {
-        return checkNotNull(argValue, "Argument cannot be null");
-    }
-
-    /**
-     * Check that the specified argument value is not {@code null}.
-     * If it is {@code null}, throw a {@link IllegalArgumentException}
-     *
-     * @param argValue the argument value to check.
-     * @throws IllegalArgumentException if the argument value is {@code null}.
-     */
-    public static <ArgT> void checkNotNull(ArgT... argValue) {
-        for (ArgT arg : argValue) {
-            if (arg == null) {
-                throw new IllegalArgumentException("Argument cannot be null");
-            }
-        }
+        return checkNotNull(argValue, "Argument was null");
     }
 
     /**
@@ -151,8 +136,7 @@ public class LiCoreSDKUtils {
      */
     public static <ArgT> ArgT checkNotNull(ArgT argValue, @Nullable String errorMessage) {
         if (argValue == null) {
-            throw new IllegalArgumentException((errorMessage == null ? "Argument cannot be null" :
-                    errorMessage));
+            throw new IllegalArgumentException((errorMessage == null ? "Argument was null" : errorMessage));
         }
         return argValue;
     }
@@ -161,8 +145,7 @@ public class LiCoreSDKUtils {
      * Ensures that a collection is not null or empty.
      */
     @NonNull
-    public static <T extends Collection<?>> T checkCollectionNotEmpty(
-            T collection, @Nullable String errorMessage) {
+    public static <T extends Collection<?>> T checkCollectionNotEmpty(T collection, @Nullable String errorMessage) {
         LiCoreSDKUtils.checkNotNull(collection, errorMessage);
         checkNotNull(!collection.isEmpty(), errorMessage);
         return collection;
@@ -172,26 +155,11 @@ public class LiCoreSDKUtils {
      * Ensures that the string is either null, or a non-empty string.
      */
     @NonNull
-    public static String checkNullOrNotEmpty(String str, @Nullable Object errorMessage) {
-        if (str != null) {
-            checkNotEmpty(str, errorMessage);
-        }
-        return str;
+    public static String checkNullOrNotEmpty(String input, @Nullable String errorMessage) {
+        checkNotNull(input, errorMessage);
+        checkArgument(!TextUtils.isEmpty(input), errorMessage != null ? errorMessage : "Argument was an empty string");
+        return input;
     }
-
-
-    /**
-     * Ensures that a string is not null or empty.
-     */
-    @NonNull
-    public static String checkNotEmpty(String str, @Nullable Object errorMessage) {
-        // ensure that we throw NullPointerException if the value is null, otherwise,
-        // IllegalArgumentException if it is empty
-        checkNotNull(str, errorMessage);
-        checkArgument(!TextUtils.isEmpty(str), String.valueOf(errorMessage));
-        return str;
-    }
-
 
     public static void checkArgument(boolean expression, @NonNull String errorTemplate, Object... params) {
         if (!expression) {

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/utils/MessageConstants.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/utils/MessageConstants.java
@@ -28,8 +28,8 @@ import android.support.annotation.NonNull;
  */
 public final class MessageConstants {
 
-    public static String ERROR_ARGUMENT_WAS_NULL = "%s was null";
-    public static String ERROR_STRING_WAS_EMPTY = "%s was empty";
+    public static String errorArgumentWasNull = "%s was null";
+    public static String errorStringWasEmpty = "%s was empty";
 
     /**
      * Default private constructor so that an instance of this
@@ -46,7 +46,7 @@ public final class MessageConstants {
      * @return the error message.
      */
     public static String wasNull(@NonNull String name) {
-        return String.format(ERROR_ARGUMENT_WAS_NULL, name);
+        return String.format(errorArgumentWasNull, name);
     }
 
     /**
@@ -57,6 +57,6 @@ public final class MessageConstants {
      * @return the error message.
      */
     public static String wasEmpty(@NonNull String name) {
-        return String.format(ERROR_STRING_WAS_EMPTY, name);
+        return String.format(errorStringWasEmpty, name);
     }
 }

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/utils/MessageConstants.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/utils/MessageConstants.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2018 Lithium Technologies Pvt Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package lithium.community.android.sdk.utils;
+
+import android.support.annotation.NonNull;
+
+/**
+ * This class hosts all messages and message templates. The value
+ * of the messages and templates can be modified by the client. All
+ * messages and templates are stored in the {@code public static}
+ * fields.
+ *
+ * @author adityasharat
+ */
+public final class MessageConstants {
+
+    public static String ERROR_ARGUMENT_WAS_NULL = "%s was null";
+    public static String ERROR_STRING_WAS_EMPTY = "%s was empty";
+
+    /**
+     * Default private constructor so that an instance of this
+     * class cannot be created.
+     */
+    private MessageConstants() {
+    }
+
+    /**
+     * Returns the error message which states that a named
+     * argument was {@code null}.
+     *
+     * @param name the name of the argument.
+     * @return the error message.
+     */
+    public static String wasNull(@NonNull String name) {
+        return String.format(ERROR_ARGUMENT_WAS_NULL, name);
+    }
+
+    /**
+     * Returns the error message which states that a named
+     * {@link String} argument was {@code null} or empty.
+     *
+     * @param name the name of the argument.
+     * @return the error message.
+     */
+    public static String wasEmpty(@NonNull String name) {
+        return String.format(ERROR_STRING_WAS_EMPTY, name);
+    }
+}

--- a/li-android-sdk-core/src/test/java/lithium/community/android/sdk/LiSDKManagerTest.java
+++ b/li-android-sdk-core/src/test/java/lithium/community/android/sdk/LiSDKManagerTest.java
@@ -30,10 +30,10 @@ import org.junit.runners.MethodSorters;
 import org.mockito.MockitoAnnotations;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 
 import lithium.community.android.sdk.auth.LiAppCredentials;
+import lithium.community.android.sdk.exception.LiInitializationException;
 import lithium.community.android.sdk.manager.LiSDKManager;
 
 import static org.junit.Assert.assertEquals;
@@ -43,82 +43,133 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 /**
- * Created by saiteja.tokala on 9/28/16.
+ * @author aiteja.tokala, adityasharat
  */
-
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 @RunWith(MockitoJUnitRunner.class)
 public class LiSDKManagerTest {
 
-
     @Rule
     public ExpectedException thrown = ExpectedException.none();
     private Activity mContext;
-    private SharedPreferences mMockSharedPreferences;
-    private Resources resource;
 
     @Before
     public void setUpTest() throws Exception {
         MockitoAnnotations.initMocks(this);
         mContext = mock(Activity.class);
-        mMockSharedPreferences = mock(SharedPreferences.class);
-        resource = mock(Resources.class);
+        SharedPreferences mMockSharedPreferences = mock(SharedPreferences.class);
+        Resources resource = mock(Resources.class);
         when(resource.getBoolean(anyInt())).thenReturn(true);
         when(mContext.getSharedPreferences(anyString(), anyInt())).thenReturn(mMockSharedPreferences);
         when(mMockSharedPreferences.getString(anyString(), anyString())).thenReturn("foobar");
         when(mContext.getResources()).thenReturn(resource);
-
-
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testInit_nullContext() throws MalformedURLException, URISyntaxException {
+    public void testInitializeWithNullContext() throws LiInitializationException {
+        //noinspection ConstantConditions for test
+        LiSDKManager.initialize(null, TestHelper.getTestAppCredentials());
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInitializeWithNullLiaCredentials() throws LiInitializationException {
+        //noinspection ConstantConditions for test
+        LiSDKManager.initialize(mContext, null);
+    }
+
+    @Test
+    public void testInitialize() throws LiInitializationException {
+        LiSDKManager.initialize(mContext, TestHelper.getTestAppCredentials());
+    }
+
+    @Test
+    public void testGetInstance() {
+        LiSDKManager instance = LiSDKManager.getInstance();
+        assert instance == null;
+    }
+
+    @Test
+    public void testInitializeOnlyOnce() throws LiInitializationException {
+        LiSDKManager.initialize(mContext, TestHelper.getTestAppCredentials());
+        LiSDKManager instance = LiSDKManager.getInstance();
+        LiSDKManager.initialize(mContext, TestHelper.getTestAppCredentials());
+        assertEquals(LiSDKManager.getInstance(), instance);
+    }
+
+    @Test
+    public void testGetLiaCredentials() throws LiInitializationException {
+        LiSDKManager.initialize(mContext, TestHelper.getTestAppCredentials());
+        LiSDKManager instance = LiSDKManager.getInstance();
+        assert instance != null;
+        LiAppCredentials liAppCredentials = instance.getLiAppCredentials();
+        assert liAppCredentials != null;
+    }
+
+    /*
+     * Following are the unit tests which are use deprecated APIs
+     */
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testInit_nullContext_deprecated() throws URISyntaxException {
+        //noinspection ConstantConditions,deprecation
         LiSDKManager.init(null, TestHelper.getTestAppCredentials());
     }
 
     @Test(expected = IllegalArgumentException.class)
-    public void testInit_nullSdkInitParams() throws MalformedURLException, URISyntaxException {
+    public void testInit_nullSdkInitParams_deprecated() throws URISyntaxException {
+        //noinspection ConstantConditions,deprecation for test
         LiSDKManager.init(mContext, null);
     }
 
     @Test
-    public void testInit() throws MalformedURLException, URISyntaxException {
+    public void testInit_deprecated() throws URISyntaxException {
+        //noinspection deprecation
         LiSDKManager.init(mContext, TestHelper.getTestAppCredentials());
-
     }
 
     @Test
-    public void testGetInstance() throws MalformedURLException, URISyntaxException {
-        LiSDKManager liSDKManager = LiSDKManager.init(
-                mContext, TestHelper.getTestAppCredentials());
+    public void testGetInstance_deprecated() throws URISyntaxException {
+        //noinspection deprecation
+        LiSDKManager liSDKManager = LiSDKManager.init(mContext, TestHelper.getTestAppCredentials());
+        assert liSDKManager != null;
+        //noinspection AccessStaticViaInstance for legacy code
         LiSDKManager instance = liSDKManager.getInstance();
         assertEquals(liSDKManager, instance);
     }
 
     @Test
-    public void testSingletonGetInstance() throws MalformedURLException, URISyntaxException {
-        LiSDKManager liSDKManager = LiSDKManager.init(mContext,
-                TestHelper.getTestAppCredentials());
+    public void testSingletonGetInstance_deprecated() throws URISyntaxException {
+        //noinspection deprecation
+        LiSDKManager liSDKManager = LiSDKManager.init(mContext, TestHelper.getTestAppCredentials());
+        assert liSDKManager != null;
+        //noinspection AccessStaticViaInstance for legacy code
         LiSDKManager instance = liSDKManager.getInstance();
         assertEquals(liSDKManager, instance);
-        LiSDKManager liClientManger2 = LiSDKManager.init(mContext,
-                TestHelper.getTestAppCredentials());
+        //noinspection deprecation
+        LiSDKManager liClientManger2 = LiSDKManager.init(mContext, TestHelper.getTestAppCredentials());
         assertEquals(liClientManger2, instance);
     }
 
     @Test
-    public void testGetAppCredentialsTest() throws MalformedURLException, URISyntaxException {
-        LiSDKManager liSDKManager = LiSDKManager.init(mContext,
-                TestHelper.getTestAppCredentials());
+    public void testGetAppCredentialsTest_deprecated() throws URISyntaxException {
+        //noinspection deprecation
+        LiSDKManager liSDKManager = LiSDKManager.init(mContext, TestHelper.getTestAppCredentials());
+        assert liSDKManager != null;
+        //noinspection AccessStaticViaInstance for legacy code
         LiSDKManager instance = liSDKManager.getInstance();
+        assert instance != null;
         LiAppCredentials liAppCredentials = instance.getLiAppCredentials();
         assertEquals(liAppCredentials, instance.getLiAppCredentials());
     }
 
     @Test
-    public void testGetAppCredentialsTestData() throws MalformedURLException, URISyntaxException {
+    public void testGetAppCredentialsTestData_deprecated() throws URISyntaxException {
+        //noinspection deprecation
         LiSDKManager liSDKManager = LiSDKManager.init(mContext, TestHelper.getTestAppCredentials());
+        assert liSDKManager != null;
+        //noinspection AccessStaticViaInstance for legacy code
         LiSDKManager instance = liSDKManager.getInstance();
+        assert instance != null;
         LiAppCredentials liAppCredentials = instance.getLiAppCredentials();
         assertEquals(liAppCredentials, instance.getLiAppCredentials());
         assertEquals(liAppCredentials.getClientSecret(), instance.getLiAppCredentials().getClientSecret());

--- a/li-android-sdk-core/src/test/java/lithium/community/android/sdk/LiSDKManagerTest.java
+++ b/li-android-sdk-core/src/test/java/lithium/community/android/sdk/LiSDKManagerTest.java
@@ -19,7 +19,6 @@ package lithium.community.android.sdk;
 import android.app.Activity;
 import android.content.SharedPreferences;
 import android.content.res.Resources;
-import android.util.NoSuchPropertyException;
 
 import org.junit.Before;
 import org.junit.FixMethodOrder;
@@ -70,12 +69,6 @@ public class LiSDKManagerTest {
         when(mContext.getResources()).thenReturn(resource);
 
 
-    }
-
-    @Test
-    public void testALiSDKManagerTestGetInstanceException() {
-        thrown.expect(NoSuchPropertyException.class);
-        LiSDKManager.getInstance();
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/li-android-sdk-core/src/test/java/lithium/community/android/sdk/TestHelper.java
+++ b/li-android-sdk-core/src/test/java/lithium/community/android/sdk/TestHelper.java
@@ -18,8 +18,6 @@ package lithium.community.android.sdk;
 
 import android.net.Uri;
 
-import java.net.MalformedURLException;
-
 import lithium.community.android.sdk.auth.LiAppCredentials;
 
 /**
@@ -283,7 +281,7 @@ public class TestHelper {
             "\t}\n" +
             "}";
 
-    public static LiAppCredentials getTestAppCredentials() throws MalformedURLException {
+    public static LiAppCredentials getTestAppCredentials() {
         return new LiAppCredentials.Builder()
                 .setClientName(TEST_CLIENT_NAME)
                 .setClientKey(TEST_CLIENT_ID)
@@ -294,7 +292,7 @@ public class TestHelper {
                 .build();
     }
 
-    public static LiAppCredentials getTestAppSSOCredentials() throws MalformedURLException {
+    public static LiAppCredentials getTestAppSSOCredentials() {
         return new LiAppCredentials.Builder()
                 .setClientName(TEST_CLIENT_NAME)
                 .setClientKey(TEST_CLIENT_ID)
@@ -304,11 +302,4 @@ public class TestHelper {
                 .setTenantId(TEST_TENANT_ID)
                 .build();
     }
-
-    /*public static LiClientManager getTestLiaClientManager(Activity context) throws MalformedURLException,
-    URISyntaxException {
-        LiClientManager liClientManger = LiClientManager.init(context);
-        LiClientManager instance = liClientManger.getInstance();
-        return instance;
-    }*/
 }

--- a/li-android-sdk-core/src/test/java/lithium/community/android/sdk/TestHelper.java
+++ b/li-android-sdk-core/src/test/java/lithium/community/android/sdk/TestHelper.java
@@ -52,29 +52,33 @@ public class TestHelper {
     public static final String ID_TOKEN = "id_token";
 
     public static final String APPLICATION_TYPE_NATIVE = "native";
+
+    public static final String TEST_CLIENT_NAME = "test";
     public static final String TEST_CLIENT_ID = "mj2gw0IYuoo33m0rKxuX4KpxUfsy7Q0rcBJhq34GHgs=";
+    public static final String TEST_API_GATEWAY_HOST = "api.qa.aws.lcloud.com";
+    public static final String TEST_TENANT_ID = "test";
+    public static final String TEST_CLIENT_SECRET = "test_client_secret";
+    public static final String TEST_COMMUNITY_URL = "http://community.lithium.com";
+
     public static final String TEST_STATE = "$TAT3";
     public static final String TEST_APP_SCHEME = "com.test.app";
+
     public static final Uri TEST_APP_REDIRECT_URI = Uri.parse(TEST_APP_SCHEME + ":/oidc_callback");
+
     public static final String TEST_SCOPE = "openid email";
-    public static final Uri TEST_IDP_AUTH_ENDPOINT =
-            Uri.parse("https://testidp.example.com/authorize");
-    public static final Uri TEST_IDP_TOKEN_ENDPOINT =
-            Uri.parse("https://testidp.example.com/token");
-    public static final Uri TEST_IDP_REGISTRATION_ENDPOINT =
-            Uri.parse("https://testidp.example.com/token");
+
+    public static final Uri TEST_IDP_AUTH_ENDPOINT = Uri.parse("https://testidp.example.com/authorize");
+    public static final Uri TEST_IDP_TOKEN_ENDPOINT = Uri.parse("https://testidp.example.com/token");
+    public static final Uri TEST_IDP_REGISTRATION_ENDPOINT = Uri.parse("https://testidp.example.com/token");
 
     public static final String TEST_CODE_VERIFIER = "0123456789_0123456789_0123456789_0123456789";
     public static final String TEST_AUTH_CODE = "zxcvbnmjk";
     public static final String TEST_ACCESS_TOKEN = "aaabbbccc";
-    public static final Long TEST_ACCESS_TOKEN_EXPIRATION_TIME = 120000L; // two minutes
     public static final String TEST_ID_TOKEN = "abc.def.ghi";
     public static final String TEST_REFRESH_TOKEN = "asdfghjkl";
+    public static final Long TEST_ACCESS_TOKEN_EXPIRATION_TIME = 120000L; // two minutes
 
     public static final Long TEST_CLIENT_SECRET_EXPIRES_AT = 78L;
-    public static final String TEST_CLIENT_SECRET = "test_client_secret";
-
-    public static final String TEST_COMMUNITY_URL = "http://community.lithium.com";
 
     public static final String TEST_EMAIL_ADDRESS = "test@example.com";
 
@@ -280,18 +284,25 @@ public class TestHelper {
             "}";
 
     public static LiAppCredentials getTestAppCredentials() throws MalformedURLException {
-        return new LiAppCredentials.Builder().setClientKey(TEST_CLIENT_ID)
+        return new LiAppCredentials.Builder()
+                .setClientName(TEST_CLIENT_NAME)
+                .setClientKey(TEST_CLIENT_ID)
                 .setClientSecret(TEST_CLIENT_SECRET)
-                .setCommunityUri(TEST_COMMUNITY_URL).setApiProxyHost("api.qa.aws.lcloud.com")
-                .setTenantId("test").build();
+                .setCommunityUri(TEST_COMMUNITY_URL)
+                .setApiGatewayUri(TEST_API_GATEWAY_HOST)
+                .setTenantId(TEST_TENANT_ID)
+                .build();
     }
 
     public static LiAppCredentials getTestAppSSOCredentials() throws MalformedURLException {
-        return new LiAppCredentials.Builder().setClientKey(TEST_CLIENT_ID)
+        return new LiAppCredentials.Builder()
+                .setClientName(TEST_CLIENT_NAME)
+                .setClientKey(TEST_CLIENT_ID)
                 .setClientSecret(TEST_CLIENT_SECRET)
                 .setCommunityUri(TEST_COMMUNITY_URL)
-                .setApiProxyHost("api.qa.aws.lcloud.com")
-                .setTenantId("test").build();
+                .setApiGatewayUri(TEST_API_GATEWAY_HOST)
+                .setTenantId(TEST_TENANT_ID)
+                .build();
     }
 
     /*public static LiClientManager getTestLiaClientManager(Activity context) throws MalformedURLException,

--- a/li-android-sdk-core/src/test/java/lithium/community/android/sdk/auth/LiAppCredentialsTest.java
+++ b/li-android-sdk-core/src/test/java/lithium/community/android/sdk/auth/LiAppCredentialsTest.java
@@ -21,8 +21,6 @@ import android.net.Uri;
 import org.junit.Assert;
 import org.junit.Test;
 
-import java.net.MalformedURLException;
-
 import lithium.community.android.sdk.utils.LiUriUtils;
 
 /**
@@ -31,27 +29,36 @@ import lithium.community.android.sdk.utils.LiUriUtils;
 
 public class LiAppCredentialsTest {
 
-    private final String ssoToken = "ssoToken";
-    private final String clientKey = "clientKey";
-    private final String clientSecret = "clientSecret";
-    private final String communityUri = "http://www.lithium.com/";
-    private final boolean deferredLogin = false;
-    private final String ssoAuthorizeUri = "http://www.lithium.com/api/2.0/auth/authorize";
-
     @Test
-    public void getParamsTest() throws MalformedURLException {
+    public void getParamsTest() {
+        String clientKey = "clientKey";
+        String clientSecret = "clientSecret";
+        String communityUri = "http://www.lithium.com/";
+        String apiGatewayHost = "http://www.lithium.com/";
+        String clientName = "name";
+        String tenantId = "tenant";
+
         LiAppCredentials liAppCredentials = new LiAppCredentials.Builder()
+                .setClientName(clientName)
                 .setClientKey(clientKey)
                 .setClientSecret(clientSecret)
+                .setTenantId(tenantId)
                 .setCommunityUri(communityUri)
+                .setApiGatewayUri(apiGatewayHost)
                 .build();
+
+        Assert.assertEquals(clientName, liAppCredentials.getClientName());
         Assert.assertEquals(clientKey, liAppCredentials.getClientKey());
         Assert.assertEquals(clientSecret, liAppCredentials.getClientSecret());
         Assert.assertEquals(Uri.parse(communityUri), liAppCredentials.getCommunityUri());
+        Assert.assertEquals(Uri.parse(apiGatewayHost), liAppCredentials.getApiGatewayHost());
+        Assert.assertEquals(apiGatewayHost, liAppCredentials.getApiProxyHost());
+        Assert.assertEquals(tenantId, liAppCredentials.getTenantId());
+
+        String ssoAuthorizeUri = "http://www.lithium.com/api/2.0/auth/authorize";
         Assert.assertEquals(ssoAuthorizeUri, liAppCredentials.getSsoAuthorizeUri());
-        Assert.assertEquals(Uri.parse(communityUri).buildUpon().path("auth/oauth2/authorize").build(),
-                liAppCredentials.getAuthorizeUri());
-        Assert.assertEquals(LiUriUtils.reverseDomainName(Uri.parse(communityUri)) + "://oauth2callback",
-                liAppCredentials.getRedirectUri());
+
+        Assert.assertEquals(Uri.parse(communityUri).buildUpon().path("auth/oauth2/authorize").build(), liAppCredentials.getAuthorizeUri());
+        Assert.assertEquals(LiUriUtils.reverseDomainName(Uri.parse(communityUri)) + "://oauth2callback", liAppCredentials.getRedirectUri());
     }
 }

--- a/li-android-sdk-core/src/test/java/lithium/community/android/sdk/auth/LiAuthServiceTest.java
+++ b/li-android-sdk-core/src/test/java/lithium/community/android/sdk/auth/LiAuthServiceTest.java
@@ -130,7 +130,7 @@ public class LiAuthServiceTest {
         try {
             liAppCredentials = TestHelper.getTestAppCredentials();
             liSDKManager = LiSDKManager.init(mContext, liAppCredentials);
-        } catch (URISyntaxException | MalformedURLException ignored) {
+        } catch (URISyntaxException ignored) {
         }
     }
 

--- a/li-android-sdk-core/src/test/java/lithium/community/android/sdk/model/LiAuthorizationExceptionTest.java
+++ b/li-android-sdk-core/src/test/java/lithium/community/android/sdk/model/LiAuthorizationExceptionTest.java
@@ -65,7 +65,7 @@ public class LiAuthorizationExceptionTest {
         MockitoAnnotations.initMocks(this);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void fromJsonNullTest() throws JSONException {
         String json = null;
         LiAuthorizationException.fromJson(json);
@@ -214,7 +214,7 @@ public class LiAuthorizationExceptionTest {
         assertEquals(null, authException.errorUri);
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test(expected = IllegalArgumentException.class)
     public void fromIntentNonNullTest() throws JSONException {
         when(mIntent.hasExtra(anyString())).thenReturn(true);
         when(LiAuthorizationException.fromJson(mIntent.getStringExtra(anyString()))).thenThrow(JSONException.class);


### PR DESCRIPTION
#### LiSDKManager
* Refactored the names of fields and methods to comply with coding standards.
* Added a new static initialization method `initialize` which will throw `LiInitializationException`. This deprecates the `init` method.
* Refactored the `getInstance()` method, it will not throw a runtime exception, but instead will return `null`.
* Refactored the constructor.
    * Removed the `throws` clause
    * Removed the `checkNotNull` usage.

#### LiAppCredentials
* Refactored the construcor
    * It is now public
    * Reordered the arguments to be more sensible
    * Removed unnecessary logic
    * Added better check null or not empty checks for the arguments
* Added `getApiGatewayHost()` which deprecates `getApiProxyHost()`.
* Updated the `hashCode` and `equals` methods.
* Refactored the `Builder` as required.
    * Marked it as deprecated as the constructor is public
    * Remove the `throws` clause.

#### LiInitializationException
* Created a new custom exception class to be thrown for all component initialization failures

#### LiCoreSDKUtils
* Remove methods with ambigous ambigous signatures

#### LiRestv2Client
* Refactored due to changes in `LiCoreSDKUtils`.

#### MessageConstants
* Created a new class which will host all messages and message templates moving forward.

#### general changelog
* Updated some of the relevant java docs.
* Added annotations to fields and methods for better static analysis.
* Updated unit test cases
* Removed style issues from
    * LiAuthRequestStore.java
    * LiBaseModelImpl.java
    * LiCoreSDKUtils.java
    * LiDefaultQueryHelper.java
    * LiQueryBuilder.java
    * LiSecuredPrefManager.java