### PR TITLE
Inject dependencies to components via constructor arguments instead of using singletons

### DIFF
--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/api/LiBaseClient.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/api/LiBaseClient.java
@@ -85,7 +85,7 @@ abstract class LiBaseClient implements LiClient {
         this.querySettingsType = querySettingsType;
         String tenant = LiSDKManager.getInstance().getTenant();
         if (tenant == null) {
-            tenant = LiSDKManager.getInstance().getLiAppCredentials().getTenantId();
+            tenant = LiSDKManager.getInstance().getCredentials().getTenantId();
         }
         this.basePath = String.format(LiAuthConstants.API_PROXY_DEFAULT_SEARCH_BASE_PATH, tenant);
         this.responseClass = responseClass;
@@ -101,7 +101,7 @@ abstract class LiBaseClient implements LiClient {
         this.querySettingsType = querySettingsType;
         String tenant = LiSDKManager.getInstance().getTenant();
         if (tenant == null) {
-            tenant = LiSDKManager.getInstance().getLiAppCredentials().getTenantId();
+            tenant = LiSDKManager.getInstance().getCredentials().getTenantId();
         }
         this.basePath = String.format(LiAuthConstants.API_PROXY_DEFAULT_GENERIC_BASE_PATH, tenant, pathParam);
         this.responseClass = responseClass;

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/auth/LiAuthServiceImpl.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/auth/LiAuthServiceImpl.java
@@ -60,19 +60,37 @@ import static lithium.community.android.sdk.utils.LiCoreSDKConstants.LI_LOG_TAG;
 public class LiAuthServiceImpl implements LiAuthService {
 
     private static final String REFRESH_TOKEN_FETCH_ERROR = "Couldn't refresh access token from refresh token";
-    @VisibleForTesting
-    protected Context mContext;
 
-    private boolean mDisposed = false;
+    @NonNull
+    private final LiSDKManager sdkManager;
+
+    @VisibleForTesting
+    protected Context context;
+
+    private boolean isDisposed = false;
 
     /**
-     * Constructor for non SSO flow
+     * Default constructor for Non-SSO flow.
      *
-     * @param context {@link Context}
+     * @param context Android context.
+     * @param manager Li SDK Manager.
+     */
+    public LiAuthServiceImpl(@NonNull Context context, @NonNull LiSDKManager manager) {
+        this.context = LiCoreSDKUtils.checkNotNull(context, "context was null");
+        this.sdkManager = LiCoreSDKUtils.checkNotNull(manager, "Li SDK Manager was null");
+    }
+
+    /**
+     * Default constructor for Non-SSO flow.
+     *
+     * @param context Android context.
+     * @deprecated use {@link #LiAuthServiceImpl(Context, LiSDKManager)} instead
      */
     public LiAuthServiceImpl(@NonNull Context context) {
-        mContext = LiCoreSDKUtils.checkNotNull(context);
+        this.context = LiCoreSDKUtils.checkNotNull(context);
+        sdkManager = LiCoreSDKUtils.checkNotNull(LiSDKManager.getInstance(), "Li SDK Manager was null");
     }
+
 
     @Override
     public void startLoginFlow() {
@@ -84,7 +102,7 @@ public class LiAuthServiceImpl implements LiAuthService {
      */
     @Override
     public void startLoginFlow(String ssoToken) {
-        LiAppCredentials liAppCredentials = LiSDKManager.getInstance().getLiAppCredentials();
+        LiAppCredentials liAppCredentials = this.sdkManager.getLiAppCredentials();
         LiSSOAuthorizationRequest authorizationRequest = new LiSSOAuthorizationRequest();
         authorizationRequest.setClientId(liAppCredentials.getClientKey());
         authorizationRequest.setRedirectUri(liAppCredentials.getRedirectUri());
@@ -111,14 +129,13 @@ public class LiAuthServiceImpl implements LiAuthService {
      * @param request {@link LiSSOAuthorizationRequest}
      */
     @Override
-    public void performAuthorizationRequest(
-            @NonNull LiSSOAuthorizationRequest request) {
+    public void performAuthorizationRequest(@NonNull LiSSOAuthorizationRequest request) {
         Uri requestUri = request.toUri();
         Intent intent;
         LiAuthRequestStore.getInstance().addAuthRequest(request);
-        intent = new Intent(mContext, LiLoginActivity.class);
+        intent = new Intent(context, LiLoginActivity.class);
         intent.setData(requestUri);
-        mContext.startActivity(intent);
+        context.startActivity(intent);
         dispose();
     }
 
@@ -127,7 +144,7 @@ public class LiAuthServiceImpl implements LiAuthService {
      * Performs Authorization (SSO flow).
      *
      * @param request {@link LiSSOAuthorizationRequest }
-     * @throws LiRestResponseException {@link LiRestResponseException}
+     * @throws LiRestResponseException throws {@link LiRestResponseException}
      */
     @Override
     public void performSSOAuthorizationRequest(@NonNull LiSSOAuthorizationRequest request) throws LiRestResponseException {
@@ -135,7 +152,7 @@ public class LiAuthServiceImpl implements LiAuthService {
         final LiAuthRestClient authRestClient = getLiAuthRestClient();
 
         LiAuthRequestStore.getInstance().addAuthRequest(request);
-        authRestClient.authorizeAsync(mContext, request, new LiAuthAsyncRequestCallback<LiBaseResponse>() {
+        authRestClient.authorizeAsync(context, request, new LiAuthAsyncRequestCallback<LiBaseResponse>() {
             @Override
             public void onSuccess(LiBaseResponse response) {
                 if (response == null || response.getHttpCode() != LiCoreSDKConstants.HTTP_CODE_SUCCESSFUL) {
@@ -150,8 +167,7 @@ public class LiAuthServiceImpl implements LiAuthService {
                 String state = liSsoAuthResponse.getState();
                 LiSSOAuthorizationRequest request = LiAuthRequestStore.getInstance().getLiOriginalRequest(state);
                 if (request == null) {
-                    Log.e(LOG_TAG, String.format(
-                            "Response received for unknown request with state %s", state));
+                    Log.e(LOG_TAG, String.format("Response received for unknown request with state %s", state));
                     enablePostAuthorizationFlows(false, LiCoreSDKConstants.HTTP_CODE_FORBIDDEN);
                     return;
                 }
@@ -181,7 +197,7 @@ public class LiAuthServiceImpl implements LiAuthService {
     /**
      * Fetching json from response and converting it back to required model.
      *
-     * @param response {@Link LiBaseResponse}
+     * @param response {@link LiBaseResponse}
      * @return Response of Authorization request.
      */
     private LiSSOAuthResponse getLiSSOAuthResponse(LiBaseResponse response) {
@@ -206,105 +222,97 @@ public class LiAuthServiceImpl implements LiAuthService {
      * @param response              {@link LiSSOAuthResponse}
      * @param authRestClient        {@link LiAuthRestClient}
      * @param loginCompleteCallBack {@link LoginCompleteCallBack}
-     * @throws LiRestResponseException {@link LiRestResponseException}
+     * @throws LiRestResponseException throws {@link LiRestResponseException}
      */
     @Override
-    public void handleAuthorizationResponse(LiSSOAuthResponse response, LiAuthRestClient authRestClient,
-            final LoginCompleteCallBack loginCompleteCallBack) throws LiRestResponseException {
-        LiSDKManager.getInstance().persistAuthState(mContext, response);
+    public void handleAuthorizationResponse(LiSSOAuthResponse response, LiAuthRestClient authRestClient, final LoginCompleteCallBack loginCompleteCallBack)
+            throws LiRestResponseException {
+        this.sdkManager.persistAuthState(context, response);
         LiSSOTokenRequest liSSOTokenRequest = new LiSSOTokenRequest();
-        liSSOTokenRequest.setClientId(LiSDKManager.getInstance().getLiAppCredentials().getClientKey());
-        liSSOTokenRequest.setRedirectUri(LiSDKManager.getInstance().getLiAppCredentials().getRedirectUri());
+        liSSOTokenRequest.setClientId(this.sdkManager.getLiAppCredentials().getClientKey());
+        liSSOTokenRequest.setRedirectUri(this.sdkManager.getLiAppCredentials().getRedirectUri());
         liSSOTokenRequest.setAccessCode(response.getAuthCode());
-        liSSOTokenRequest.setClientSecret(LiSDKManager.getInstance().getLiAppCredentials().getClientSecret());
+        liSSOTokenRequest.setClientSecret(this.sdkManager.getLiAppCredentials().getClientSecret());
         liSSOTokenRequest.setGrantType("authorization_code");
-        if (response != null) {
-            try {
-                String proxyHost;
-                if (response.getApiProxyHost() == null) {
-                    proxyHost = LiSDKManager.getInstance().getLiAppCredentials().getApiProxyHost();
-                } else {
-                    proxyHost = response.getApiProxyHost();
-                }
-                String uri = "https://" + proxyHost + "/auth/v1/accessToken";
-                liSSOTokenRequest.setUri(Uri.parse(uri));
-                authRestClient.accessTokenAsync(mContext, liSSOTokenRequest, new LiAuthAsyncRequestCallback<LiBaseResponse>() {
-                    @Override
-                    public void onSuccess(LiBaseResponse response) throws LiRestResponseException {
-                        if (response == null || response.getHttpCode() != LiCoreSDKConstants.HTTP_CODE_SUCCESSFUL) {
-                            Log.e(LOG_TAG, "Error fetching access token");
-                            loginCompleteCallBack.onLoginComplete(LiAuthorizationException.generalEx(
-                                    LiAuthorizationException.GeneralErrors.SERVER_ERROR.code, "Error fetching access token"), false);
-                            return;
-                        }
-                        Gson gson = new Gson();
-                        JsonObject data = LiClientManager.getRestClient().getGson().fromJson(response.getData(), JsonObject.class);
-                        if (data != null
-                                && data.has("response")) {
-                            JsonObject responseObject = data.get("response").getAsJsonObject();
-                            if (responseObject.has("data")) {
-                                JsonElement dataObjElement = responseObject.get("data");
-                                LiTokenResponse tokenResponse = gson.fromJson(dataObjElement, LiTokenResponse.class);
-                                tokenResponse.setExpiresAt(LiCoreSDKUtils.getTime(tokenResponse.getExpiresIn()));
-                                JsonObject dataJsonObject = dataObjElement.getAsJsonObject();
-                                dataJsonObject.addProperty("expiresAt", tokenResponse.getExpiresAt());
-                                tokenResponse.setJsonString(String.valueOf(dataJsonObject));
-                                LiSDKManager.getInstance().persistAuthState(mContext, tokenResponse);
-                                getUserAfterTokenResponse(loginCompleteCallBack);
-                            }
-                        } else {
-                            loginCompleteCallBack.onLoginComplete(LiAuthorizationException.generalEx(
-                                    response.getHttpCode(),
-                                    "Error fetching accessToken"), false);
-                        }
-                    }
-
-                    @Override
-                    public void onError(Exception e) {
-                        Log.e(LOG_TAG, "Error fetching access token: " + e);
-                        loginCompleteCallBack.onLoginComplete(LiAuthorizationException.generalEx(
-                                LiAuthorizationException.GeneralErrors.SERVER_ERROR.code, e.getMessage()), false);
-
-                    }
-                });
-            } catch (RuntimeException e) {
-                Log.e(LiAuthConstants.LOG_TAG, e.getMessage());
-                throw LiRestResponseException.runtimeError(e.getMessage());
+        try {
+            String proxyHost;
+            if (response.getApiProxyHost() == null) {
+                proxyHost = this.sdkManager.getLiAppCredentials().getApiGatewayHost().toString();
+            } else {
+                proxyHost = response.getApiProxyHost();
             }
-        } else {
-            loginCompleteCallBack.onLoginComplete(null, false);
+            String uri = "https://" + proxyHost + "/auth/v1/accessToken";
+            liSSOTokenRequest.setUri(Uri.parse(uri));
+            authRestClient.accessTokenAsync(context, liSSOTokenRequest, new LiAuthAsyncRequestCallback<LiBaseResponse>() {
+                @Override
+                public void onSuccess(LiBaseResponse response) throws LiRestResponseException {
+                    if (response == null || response.getHttpCode() != LiCoreSDKConstants.HTTP_CODE_SUCCESSFUL) {
+                        Log.e(LOG_TAG, "Error fetching access token");
+                        loginCompleteCallBack.onLoginComplete(LiAuthorizationException.generalEx(
+                                LiAuthorizationException.GeneralErrors.SERVER_ERROR.code, "Error fetching access token"), false);
+                        return;
+                    }
+                    Gson gson = new Gson();
+                    JsonObject data = LiClientManager.getRestClient().getGson().fromJson(response.getData(), JsonObject.class);
+                    if (data != null
+                            && data.has("response")) {
+                        JsonObject responseObject = data.get("response").getAsJsonObject();
+                        if (responseObject.has("data")) {
+                            JsonElement dataObjElement = responseObject.get("data");
+                            LiTokenResponse tokenResponse = gson.fromJson(dataObjElement, LiTokenResponse.class);
+                            tokenResponse.setExpiresAt(LiCoreSDKUtils.getTime(tokenResponse.getExpiresIn()));
+                            JsonObject dataJsonObject = dataObjElement.getAsJsonObject();
+                            dataJsonObject.addProperty("expiresAt", tokenResponse.getExpiresAt());
+                            tokenResponse.setJsonString(String.valueOf(dataJsonObject));
+                            sdkManager.persistAuthState(context, tokenResponse);
+                            getUserAfterTokenResponse(loginCompleteCallBack);
+                        }
+                    } else {
+                        loginCompleteCallBack.onLoginComplete(LiAuthorizationException.generalEx(
+                                response.getHttpCode(),
+                                "Error fetching accessToken"), false);
+                    }
+                }
+
+                @Override
+                public void onError(Exception e) {
+                    Log.e(LOG_TAG, "Error fetching access token: " + e);
+                    LiAuthorizationException ex = LiAuthorizationException.generalEx(LiAuthorizationException.GeneralErrors.SERVER_ERROR.code, e.getMessage());
+                    loginCompleteCallBack.onLoginComplete(ex, false);
+
+                }
+            });
+        } catch (RuntimeException e) {
+            Log.e(LiAuthConstants.LOG_TAG, e.getMessage());
+            throw LiRestResponseException.runtimeError(e.getMessage());
         }
     }
 
     /**
      * Fetches setting details from the community post user login
      *
-     * @param loginCompleteCallBack {@Link LoginCompleteCallBack}
+     * @param loginCompleteCallBack {@link LoginCompleteCallBack}
      */
     private void getSDKSettings(final LoginCompleteCallBack loginCompleteCallBack) {
         try {
-            String clientId = LiUUIDUtils.toUUID(LiSDKManager.getInstance().getLiAppCredentials().getClientKey().getBytes()).toString();
-            LiClientRequestParams liClientRequestParams = new LiClientRequestParams.LiSdkSettingsClientRequestParams(mContext, clientId);
+            String clientId = LiUUIDUtils.toUUID(this.sdkManager.getLiAppCredentials().getClientKey().getBytes()).toString();
+            LiClientRequestParams liClientRequestParams = new LiClientRequestParams.LiSdkSettingsClientRequestParams(context, clientId);
             LiClient settingsClient = LiClientManager.getSdkSettingsClient(liClientRequestParams);
             settingsClient.processAsync(new LiAsyncRequestCallback<LiGetClientResponse>() {
                 @Override
                 public void onSuccess(LiBaseRestRequest request,
-                        LiGetClientResponse response) throws LiRestResponseException {
+                                      LiGetClientResponse response) throws LiRestResponseException {
                     if (response != null && response.getHttpCode() == LiCoreSDKConstants.HTTP_CODE_SUCCESSFUL) {
                         Gson gson = new Gson();
                         JsonObject responseJsonObject = response.getJsonObject();
                         if (responseJsonObject.has("data")) {
-                            JsonObject dataObj = responseJsonObject.get("data")
-                                    .getAsJsonObject();
+                            JsonObject dataObj = responseJsonObject.get("data").getAsJsonObject();
                             if (dataObj.has("items")) {
                                 JsonArray items = dataObj.get("items").getAsJsonArray();
                                 if (!items.isJsonNull() && items.size() > 0) {
-                                    LiAppSdkSettings liAppSdkSettings =
-                                            gson.fromJson(items.get(0), LiAppSdkSettings.class);
+                                    LiAppSdkSettings liAppSdkSettings = gson.fromJson(items.get(0), LiAppSdkSettings.class);
                                     if (liAppSdkSettings != null) {
-                                        LiSDKManager.getInstance().putInSecuredPreferences(
-                                                mContext,
-                                                LI_DEFAULT_SDK_SETTINGS,
+                                        sdkManager.putInSecuredPreferences(context, LI_DEFAULT_SDK_SETTINGS,
                                                 liAppSdkSettings.getAdditionalInformation());
                                     }
                                 }
@@ -314,9 +322,9 @@ public class LiAuthServiceImpl implements LiAuthService {
                         Log.e(LiCoreSDKConstants.LI_LOG_TAG, "Error getting SDK settings");
                     }
 
-                    LiDeviceTokenProvider liDeviceTokenProvider = LiSDKManager.getInstance().getLiDeviceTokenProvider();
+                    LiDeviceTokenProvider liDeviceTokenProvider = sdkManager.getLiDeviceTokenProvider();
                     if (liDeviceTokenProvider != null && !TextUtils.isEmpty(liDeviceTokenProvider.getDeviceId())) {
-                        new LiNotificationProviderImpl().onIdRefresh(liDeviceTokenProvider.getDeviceId(), mContext);
+                        new LiNotificationProviderImpl().onIdRefresh(liDeviceTokenProvider.getDeviceId(), context);
                     }
 
                     loginCompleteCallBack.onLoginComplete(null, true);
@@ -343,30 +351,26 @@ public class LiAuthServiceImpl implements LiAuthService {
     @VisibleForTesting
     public void getUserAfterTokenResponse(final LoginCompleteCallBack loginCompleteCallBack) {
         try {
-            LiClientRequestParams liClientRequestParams = new LiClientRequestParams.LiUserDetailsClientRequestParams(mContext, "self");
-            LiClientManager.getUserDetailsClient(liClientRequestParams)
-                    .processAsync(new LiAsyncRequestCallback<LiGetClientResponse>() {
-                        @Override
-                        public void onSuccess(LiBaseRestRequest request, LiGetClientResponse
-                                liClientResponse) throws LiRestResponseException {
-                            if (liClientResponse != null
-                                    && liClientResponse.getHttpCode() == LiCoreSDKConstants.HTTP_CODE_SUCCESSFUL
-                                    && liClientResponse.getResponse() != null
-                                    && !liClientResponse.getResponse().isEmpty()) {
-                                LiUser user = (LiUser) liClientResponse.getResponse().get(0).getModel();
-                                LiSDKManager.getInstance().setLoggedInUser(mContext, user);
-                            }
-                            getSDKSettings(loginCompleteCallBack);
-                        }
+            LiClientRequestParams liClientRequestParams = new LiClientRequestParams.LiUserDetailsClientRequestParams(context, "self");
+            LiClientManager.getUserDetailsClient(liClientRequestParams).processAsync(new LiAsyncRequestCallback<LiGetClientResponse>() {
+                @Override
+                public void onSuccess(LiBaseRestRequest request, LiGetClientResponse liClientResponse) throws LiRestResponseException {
+                    if (liClientResponse != null && liClientResponse.getHttpCode() == LiCoreSDKConstants.HTTP_CODE_SUCCESSFUL
+                            && liClientResponse.getResponse() != null && !liClientResponse.getResponse().isEmpty()) {
+                        LiUser user = (LiUser) liClientResponse.getResponse().get(0).getModel();
+                        sdkManager.setLoggedInUser(context, user);
+                    }
+                    getSDKSettings(loginCompleteCallBack);
+                }
 
-                        @Override
-                        public void onError(Exception e) {
-                            getSDKSettings(loginCompleteCallBack);
-                            Log.e(LOG_TAG, "Unable to fetch user details: " + e);
-                            loginCompleteCallBack.onLoginComplete(LiAuthorizationException.generalEx(
-                                    LiAuthorizationException.GeneralErrors.SERVER_ERROR.code, e.getMessage()), false);
-                        }
-                    });
+                @Override
+                public void onError(Exception e) {
+                    getSDKSettings(loginCompleteCallBack);
+                    Log.e(LOG_TAG, "Unable to fetch user details: " + e);
+                    LiAuthorizationException ex = LiAuthorizationException.generalEx(LiAuthorizationException.GeneralErrors.SERVER_ERROR.code, e.getMessage());
+                    loginCompleteCallBack.onLoginComplete(ex, false);
+                }
+            });
         } catch (LiRestResponseException e) {
             Log.e(LOG_TAG, "ERROR: " + e);
             getSDKSettings(loginCompleteCallBack);
@@ -378,22 +382,22 @@ public class LiAuthServiceImpl implements LiAuthService {
      * Fetching fresh access token from refresh token. Its Asyn call.
      *
      * @param callback {@link LiTokenResponseCallback}
-     * @throws LiRestResponseException {@link LiRestResponseException}
+     * @throws LiRestResponseException throws {@link LiRestResponseException}
      */
     @Override
     public void performRefreshTokenRequest(@NonNull final LiTokenResponseCallback callback) throws LiRestResponseException {
         checkIfDisposed();
         final LiAuthRestClient authRestClient = getLiAuthRestClient();
         LiRefreshTokenRequest liRefreshTokenRequest = new LiRefreshTokenRequest();
-        liRefreshTokenRequest.setClientId(LiSDKManager.getInstance().getLiAppCredentials().getClientKey());
-        liRefreshTokenRequest.setClientSecret(LiSDKManager.getInstance().getLiAppCredentials().getClientSecret());
+        liRefreshTokenRequest.setClientId(this.sdkManager.getLiAppCredentials().getClientKey());
+        liRefreshTokenRequest.setClientSecret(this.sdkManager.getLiAppCredentials().getClientSecret());
         liRefreshTokenRequest.setGrantType("refresh_token");
-        liRefreshTokenRequest.setRefreshToken(LiSDKManager.getInstance().getRefreshToken());
-        String uri = "https://" + LiSDKManager.getInstance().getProxyHost() + "/auth/v1/refreshToken";
+        liRefreshTokenRequest.setRefreshToken(this.sdkManager.getRefreshToken());
+        String uri = "https://" + this.sdkManager.getProxyHost() + "/auth/v1/refreshToken";
         liRefreshTokenRequest.setUri(Uri.parse(uri));
 
         try {
-            authRestClient.refreshTokenAsync(mContext, liRefreshTokenRequest, new LiAuthAsyncRequestCallback<LiBaseResponse>() {
+            authRestClient.refreshTokenAsync(context, liRefreshTokenRequest, new LiAuthAsyncRequestCallback<LiBaseResponse>() {
 
                 @Override
                 public void onSuccess(LiBaseResponse response) throws LiRestResponseException {
@@ -404,8 +408,7 @@ public class LiAuthServiceImpl implements LiAuthService {
                     try {
                         Gson gson = new Gson();
                         JsonObject data = gson.fromJson(response.getData(), JsonObject.class);
-                        if (data != null
-                                && data.has("response")) {
+                        if (data != null && data.has("response")) {
                             JsonObject responseJsonObj = data.get("response").getAsJsonObject();
                             if (responseJsonObj.has("data")) {
                                 LiTokenResponse tokenResponse = gson.fromJson(responseJsonObj.get("data"), LiTokenResponse.class);
@@ -443,22 +446,22 @@ public class LiAuthServiceImpl implements LiAuthService {
      * Fetching fresh access token from refresh token. Its a Sync call.
      *
      * @return Refresh Token {@link LiTokenResponse}
-     * @throws LiRestResponseException {@link LiRestResponseException}
+     * @throws LiRestResponseException throws {@link LiRestResponseException}
      */
     @Override
     public LiTokenResponse performSyncRefreshTokenRequest() throws LiRestResponseException {
 
         final LiAuthRestClient authRestClient = getLiAuthRestClient();
         LiRefreshTokenRequest liRefreshTokenRequest = new LiRefreshTokenRequest();
-        liRefreshTokenRequest.setClientId(LiSDKManager.getInstance().getLiAppCredentials().getClientKey());
-        liRefreshTokenRequest.setClientSecret(LiSDKManager.getInstance().getLiAppCredentials().getClientSecret());
+        liRefreshTokenRequest.setClientId(this.sdkManager.getLiAppCredentials().getClientKey());
+        liRefreshTokenRequest.setClientSecret(this.sdkManager.getLiAppCredentials().getClientSecret());
         liRefreshTokenRequest.setGrantType("refresh_token");
-        liRefreshTokenRequest.setRefreshToken(LiSDKManager.getInstance().getRefreshToken());
-        String uri = "https://" + LiSDKManager.getInstance().getProxyHost() + "/auth/v1/refreshToken";
+        liRefreshTokenRequest.setRefreshToken(this.sdkManager.getRefreshToken());
+        String uri = "https://" + this.sdkManager.getProxyHost() + "/auth/v1/refreshToken";
         liRefreshTokenRequest.setUri(Uri.parse(uri));
 
         LiTokenResponse tokenResponse = null;
-        LiBaseResponse resp = authRestClient.refreshTokenSync(mContext, liRefreshTokenRequest);
+        LiBaseResponse resp = authRestClient.refreshTokenSync(context, liRefreshTokenRequest);
         Gson gson = new Gson();
         JsonObject dataObject = resp.getData();
         try {
@@ -491,7 +494,7 @@ public class LiAuthServiceImpl implements LiAuthService {
      */
     @Override
     public void enablePostAuthorizationFlows(boolean isLoginSuccess, int responseCode) {
-        LiCoreSDKUtils.sendLoginBroadcast(mContext, isLoginSuccess, responseCode);
+        LiCoreSDKUtils.sendLoginBroadcast(context, isLoginSuccess, responseCode);
         this.dispose();
     }
 
@@ -500,17 +503,15 @@ public class LiAuthServiceImpl implements LiAuthService {
      */
     @Override
     public void dispose() {
-        if (mDisposed) {
+        if (isDisposed) {
             return;
         }
-        mDisposed = true;
+        isDisposed = true;
     }
 
     private void checkIfDisposed() {
-        if (mDisposed) {
+        if (isDisposed) {
             throw new IllegalStateException("Service has been disposed and rendered inoperable");
         }
     }
-
-
 }

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/auth/LiLoginActivity.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/auth/LiLoginActivity.java
@@ -36,14 +36,18 @@ import android.widget.ProgressBar;
 import android.widget.TextView;
 
 import lithium.community.android.sdk.R;
+import lithium.community.android.sdk.manager.LiSDKManager;
 import lithium.community.android.sdk.utils.LiCoreSDKConstants;
 import lithium.community.android.sdk.utils.LiCoreSDKUtils;
 
 /**
+ * <p>
  * Activity that receives the redirect Uri sent by the OpenID endpoint. This activity gets launched
  * when the user approves the app for use and it starts the {@link PendingIntent} given in
  * {@link LiAuthService#performAuthorizationRequest}.
- * <p>App developers using this library <em>must</em> to register this activity in the manifest
+ * </p>
+ * <p>
+ * App developers using this library <em>must</em> to register this activity in the manifest
  * with one intent filter for each redirect URI they are intending to use.
  * </p>
  */
@@ -78,47 +82,49 @@ public class LiLoginActivity extends LiBaseAuthActivity {
             getSupportActionBar().setDisplayHomeAsUpEnabled(true);
         }
 
-        service = new LiAuthServiceImpl(this);
+        LiSDKManager manager = LiSDKManager.getInstance();
+        if (manager != null) {
+            service = new LiAuthServiceImpl(this, manager);
 
-        webViewOauth = findViewById(R.id.li_web_oauth);
-        progressBar = findViewById(R.id.li_login_page_prog_bar);
-        tvLoginInProgress = findViewById(R.id.li_login_in_prog_txt);
+            webViewOauth = findViewById(R.id.li_web_oauth);
+            progressBar = findViewById(R.id.li_login_page_prog_bar);
+            tvLoginInProgress = findViewById(R.id.li_login_in_prog_txt);
 
-        progressBar.setVisibility(View.VISIBLE);
-        webViewOauth.setVisibility(View.INVISIBLE);
-        tvLoginInProgress.setText(getString(R.string.li_openingLoginPage));
-        tvLoginInProgress.setVisibility(View.VISIBLE);
+            progressBar.setVisibility(View.VISIBLE);
+            webViewOauth.setVisibility(View.INVISIBLE);
+            tvLoginInProgress.setText(getString(R.string.li_openingLoginPage));
+            tvLoginInProgress.setVisibility(View.VISIBLE);
 
-        isAccessTokenSaved = false;
+            isAccessTokenSaved = false;
 
-        webViewOauth.clearHistory();
-        webViewOauth.clearFormData();
-        webViewOauth.clearCache(true);
+            webViewOauth.clearHistory();
+            webViewOauth.clearFormData();
+            webViewOauth.clearCache(true);
 
-        Intent intent = getIntent();
-        Uri uri = intent.getData();
+            Intent intent = getIntent();
+            Uri uri = intent.getData();
 
-        if (uri != null) {
-            String url = intent.getData().toString();
-            setTitle(url);
+            if (uri != null) {
+                String url = intent.getData().toString();
+                setTitle(url);
 
-            //set the web client
-            webViewOauth.setWebViewClient(new LoginWebViewClient());
-            webViewOauth.setWebChromeClient(new LoginWebChromeClient());
+                //set the web client
+                webViewOauth.setWebViewClient(new LoginWebViewClient());
+                webViewOauth.setWebChromeClient(new LoginWebChromeClient());
 
-            //activates JavaScript (just in case)
-            WebSettings webSettings = webViewOauth.getSettings();
-            webSettings.setJavaScriptEnabled(true);
-            webSettings.setCacheMode(WebSettings.LOAD_NO_CACHE);
-            webSettings.setAppCacheEnabled(false);
+                //activates JavaScript (just in case)
+                WebSettings webSettings = webViewOauth.getSettings();
+                webSettings.setJavaScriptEnabled(true);
+                webSettings.setCacheMode(WebSettings.LOAD_NO_CACHE);
+                webSettings.setAppCacheEnabled(false);
 
-            //load the url of the oAuth login page
-            webViewOauth.loadUrl(url);
-        } else {
-            tvLoginInProgress.setText(R.string.li_login_error_missing_url);
-            Log.e("LiLoginActivity", "Login page url is null.");
+                //load the url of the oAuth login page
+                webViewOauth.loadUrl(url);
+            } else {
+                tvLoginInProgress.setText(R.string.li_login_error_missing_url);
+                Log.e("LiLoginActivity", "Login page url is null.");
+            }
         }
-
     }
 
     private class LoginWebChromeClient extends WebChromeClient {

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiAuthManager.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiAuthManager.java
@@ -32,6 +32,8 @@ import lithium.community.android.sdk.auth.LiSSOAuthResponse;
 import lithium.community.android.sdk.auth.LiTokenResponse;
 import lithium.community.android.sdk.model.response.LiUser;
 import lithium.community.android.sdk.utils.LiCoreSDKConstants;
+import lithium.community.android.sdk.utils.LiCoreSDKUtils;
+import lithium.community.android.sdk.utils.MessageConstants;
 
 import static lithium.community.android.sdk.utils.LiCoreSDKConstants.LI_AUTH_STATE;
 import static lithium.community.android.sdk.utils.LiCoreSDKConstants.LI_DEFAULT_SDK_SETTINGS;
@@ -49,13 +51,13 @@ import static lithium.community.android.sdk.utils.LiCoreSDKConstants.LI_RECEIVER
 class LiAuthManager {
 
     @NonNull
-    private final LiAppCredentials liAppCredentials;
+    private final LiAppCredentials credentials;
 
     private LiAuthState liAuthState;
 
-    LiAuthManager(@NonNull Context context, @NonNull LiAppCredentials liAppCredentials) {
-        this.liAuthState = restoreAuthState(context);
-        this.liAppCredentials = liAppCredentials;
+    LiAuthManager(@NonNull Context context, @NonNull LiAppCredentials credentials) {
+        this.liAuthState = restoreAuthState(LiCoreSDKUtils.checkNotNull(context, MessageConstants.wasNull("context")));
+        this.credentials = LiCoreSDKUtils.checkNotNull(credentials, MessageConstants.wasNull("credentials"));
     }
 
     /**
@@ -64,18 +66,29 @@ class LiAuthManager {
      * @return the credentials.
      */
     @NonNull
+    public LiAppCredentials getCredentials() {
+        return credentials;
+    }
+
+    /**
+     * Get the credentials used to initialize the SDK.
+     *
+     * @return the credentials.
+     * @deprecated Use {@link #getCredentials()} instead.
+     */
+    @NonNull
     public LiAppCredentials getLiAppCredentials() {
-        return liAppCredentials;
+        return credentials;
     }
 
     /**
      * Get the Community URI.
      *
      * @return the community URI.
-     * @deprecated Use {@link #getLiAppCredentials()} and call {@link LiAppCredentials#getCommunityUri()} instead.
+     * @deprecated Use {@link #getCredentials()} and call {@link LiAppCredentials#getCommunityUri()} instead.
      */
     public Uri getCommunityUrl() {
-        return liAppCredentials.getCommunityUri();
+        return credentials.getCommunityUri();
     }
 
     /**
@@ -117,12 +130,14 @@ class LiAuthManager {
     }
 
     public String getFromSecuredPreferences(Context context, String key) {
-        return LiSecuredPrefManager.getInstance() == null ? null : LiSecuredPrefManager.getInstance().getString(context, key);
+        LiSecuredPrefManager manager = LiSecuredPrefManager.getInstance();
+        return manager == null ? null : manager.getString(context, key);
     }
 
     public boolean putInSecuredPreferences(Context context, String key, String value) {
-        if (LiSecuredPrefManager.getInstance() != null) {
-            LiSecuredPrefManager.getInstance().putString(context, key, value);
+        LiSecuredPrefManager manager = LiSecuredPrefManager.getInstance();
+        if (manager != null) {
+            manager.putString(context, key, value);
             return true;
         } else {
             return false;
@@ -130,8 +145,9 @@ class LiAuthManager {
     }
 
     public boolean removeFromSecuredPreferences(Context context, String key) {
-        if (LiSecuredPrefManager.getInstance() != null) {
-            LiSecuredPrefManager.getInstance().remove(context, key);
+        LiSecuredPrefManager manager = LiSecuredPrefManager.getInstance();
+        if (manager != null) {
+            manager.remove(context, key);
             return true;
         } else {
             return false;
@@ -232,7 +248,7 @@ class LiAuthManager {
     public String getProxyHost() {
         String proxyHost;
         if (liAuthState == null || TextUtils.isEmpty(liAuthState.getProxyHost())) {
-            proxyHost = liAppCredentials.getApiGatewayHost().toString();
+            proxyHost = credentials.getApiGatewayHost().toString();
         } else {
             proxyHost = liAuthState.getProxyHost();
         }
@@ -245,7 +261,7 @@ class LiAuthManager {
     public String getTenant() {
         String tenant;
         if (liAuthState == null || TextUtils.isEmpty(liAuthState.getTenantId())) {
-            tenant = liAppCredentials.getTenantId();
+            tenant = credentials.getTenantId();
         } else {
             tenant = liAuthState.getTenantId();
         }

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiAuthState.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiAuthState.java
@@ -43,7 +43,6 @@ import static lithium.community.android.sdk.utils.LiCoreSDKUtils.checkNullOrNotE
  * This class holds all the Authorization related responses and the Tokens.
  * Created by kunal.shrivastava on 10/18/16.
  */
-@VisibleForTesting
 class LiAuthState {
 
     private static final String LOG_TAG = "LiSDKAuth";

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiClientManager.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiClientManager.java
@@ -712,7 +712,7 @@ public class LiClientManager {
         final LiUserDeviceDataModel liUserDeviceDataModel = new LiUserDeviceDataModel();
         liUserDeviceDataModel.setType(LiQueryConstant.LI_USER_DEVICE_ID_FETCH_TYPE);
         liUserDeviceDataModel.setDeviceId(deviceId);
-        liUserDeviceDataModel.setClientId(LiSDKManager.getInstance().getLiAppCredentials().getClientKey());
+        liUserDeviceDataModel.setClientId(LiSDKManager.getInstance().getCredentials().getClientKey());
         liUserDeviceDataModel.setApplicationType(LiQueryConstant.LI_APPLICATION_TYPE);
         liUserDeviceDataModel.setPushNotificationProvider(pushNotificationProvider);
         liBasePostClient.postModel = liUserDeviceDataModel;

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiSDKManager.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiSDKManager.java
@@ -17,7 +17,6 @@
 package lithium.community.android.sdk.manager;
 
 import android.content.Context;
-import android.net.Uri;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.util.Log;
@@ -32,6 +31,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import lithium.community.android.sdk.BuildConfig;
 import lithium.community.android.sdk.auth.LiAppCredentials;
 import lithium.community.android.sdk.auth.LiAuthConstants;
+import lithium.community.android.sdk.auth.LiAuthService;
+import lithium.community.android.sdk.auth.LiAuthServiceImpl;
+import lithium.community.android.sdk.auth.LiDeviceTokenProvider;
+import lithium.community.android.sdk.auth.LiTokenResponse;
 import lithium.community.android.sdk.exception.LiInitializationException;
 import lithium.community.android.sdk.exception.LiRestResponseException;
 import lithium.community.android.sdk.model.request.LiClientRequestParams;
@@ -61,10 +64,13 @@ public final class LiSDKManager extends LiAuthManager {
     private static AtomicBoolean isInitialized = new AtomicBoolean(false);
     private static LiSDKManager instance;
 
+    @Nullable
+    private LiDeviceTokenProvider deviceTokenProvider;
+
     /**
      * Default private constructor.
      *
-     * @param context     The Android context
+     * @param context     The Android context.
      * @param credentials The credentials to be used to authenticate the SDK.
      */
     private LiSDKManager(@NonNull Context context, @NonNull LiAppCredentials credentials) {
@@ -168,7 +174,7 @@ public final class LiSDKManager extends LiAuthManager {
     public void syncWithCommunity(final Context context) {
         if (instance.isUserLoggedIn()) {
             try {
-                String clientId = LiUUIDUtils.toUUID(liAppCredentials.getClientKey().getBytes()).toString();
+                String clientId = LiUUIDUtils.toUUID(getLiAppCredentials().getClientKey().getBytes()).toString();
                 LiClientRequestParams liClientRequestParams = new LiClientRequestParams.LiSdkSettingsClientRequestParams(context, clientId);
                 LiClientManager.getSdkSettingsClient(liClientRequestParams).processAsync(
                         new LiAsyncRequestCallback<LiGetClientResponse>() {
@@ -233,24 +239,97 @@ public final class LiSDKManager extends LiAuthManager {
     }
 
     /**
-     * Returns community URI.
+     * Gets version name of the SDK.
+     *
+     * @return the version name of the SDK.
      */
-    public Uri getCommunityUrl() {
-        return liAppCredentials.getCommunityUri();
-    }
-
-    /**
-     * Returns AppCredentials.
-     */
-    public LiAppCredentials getLiAppCredentials() {
-        return liAppCredentials;
-    }
-
-    /**
-     * gets the core sdk version
-     */
+    @NonNull
     public String getCoreSDKVersion() {
         return BuildConfig.li_sdk_core_version;
+    }
+
+    /**
+     * Get the device token provider currently being used by the SDK.
+     *
+     * @return the device token provider.
+     */
+    @Nullable
+    public LiDeviceTokenProvider getLiDeviceTokenProvider() {
+        return deviceTokenProvider;
+    }
+
+    /**
+     * Set a new device token provider to be used by the SDK.
+     *
+     * @param deviceTokenProvider A device token provider.
+     */
+    public void setLiDeviceTokenProvider(@Nullable LiDeviceTokenProvider deviceTokenProvider) {
+        this.deviceTokenProvider = deviceTokenProvider;
+    }
+
+    /**
+     * Start SSO login.
+     *
+     * @param context             An Android context.
+     * @param ssoToken            Single SignOn token if the community uses its own identity provider.
+     * @param deviceTokenProvider Provider to get the device ID for push notifications. A Firebase or GCM token.
+     */
+    public void initLoginFlow(Context context, String ssoToken, LiDeviceTokenProvider deviceTokenProvider) {
+        this.deviceTokenProvider = deviceTokenProvider;
+        if (!isUserLoggedIn()) {
+            new LiAuthServiceImpl(context, this).startLoginFlow(ssoToken);
+        }
+    }
+
+    /**
+     * Start SSO login.
+     *
+     * @param context  An Android context.
+     * @param ssoToken Single SignOn token if the community uses its own identity provider.
+     */
+    public void initLoginFlow(Context context, String ssoToken) throws URISyntaxException {
+        initLoginFlow(context, ssoToken, null);
+    }
+
+    /**
+     * Start community login.
+     *
+     * @param context             An Android context.
+     * @param deviceTokenProvider Provider to get the device ID for push notifications. A Firebase or GCM token.
+     */
+    public void initLoginFlow(Context context, LiDeviceTokenProvider deviceTokenProvider) {
+        this.deviceTokenProvider = deviceTokenProvider;
+        initLoginFlow(context, null, deviceTokenProvider);
+    }
+
+    /**
+     * Start anonymous login.
+     *
+     * @param context An Android context object.
+     */
+    public void initLoginFlow(Context context) {
+        initLoginFlow(context, null, null);
+    }
+
+    /**
+     * Fetches Fresh Access Token and Persists it.
+     *
+     * @param context             An Android context.
+     * @param mFreshTokenCallBack {@link LiAuthService.FreshTokenCallBack}
+     * @throws LiRestResponseException An exception is thrown when an invalid response is received by the SDK.
+     */
+    public void fetchFreshAccessToken(final Context context, final LiAuthService.FreshTokenCallBack mFreshTokenCallBack) throws LiRestResponseException {
+        new LiAuthServiceImpl(context, this).performRefreshTokenRequest(new LiAuthService.LiTokenResponseCallback() {
+            @Override
+            public void onTokenRequestCompleted(@Nullable LiTokenResponse response, @Nullable Exception ex) {
+                if (ex != null) {
+                    mFreshTokenCallBack.onFreshTokenFetched(false);
+                    return;
+                }
+                persistAuthState(context, response);
+                mFreshTokenCallBack.onFreshTokenFetched(true);
+            }
+        });
     }
 }
 

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiSDKManager.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiSDKManager.java
@@ -174,7 +174,7 @@ public final class LiSDKManager extends LiAuthManager {
     public void syncWithCommunity(final Context context) {
         if (instance.isUserLoggedIn()) {
             try {
-                String clientId = LiUUIDUtils.toUUID(getLiAppCredentials().getClientKey().getBytes()).toString();
+                String clientId = LiUUIDUtils.toUUID(getCredentials().getClientKey().getBytes()).toString();
                 LiClientRequestParams liClientRequestParams = new LiClientRequestParams.LiSdkSettingsClientRequestParams(context, clientId);
                 LiClientManager.getSdkSettingsClient(liClientRequestParams).processAsync(
                         new LiAsyncRequestCallback<LiGetClientResponse>() {

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/rest/LiRestClient.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/rest/LiRestClient.java
@@ -39,7 +39,6 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Type;
 import java.net.URI;
-import java.net.URISyntaxException;
 import java.nio.charset.Charset;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
@@ -56,6 +55,7 @@ import lithium.community.android.sdk.R;
 import lithium.community.android.sdk.auth.LiAuthConstants;
 import lithium.community.android.sdk.auth.LiAuthServiceImpl;
 import lithium.community.android.sdk.auth.LiTokenResponse;
+import lithium.community.android.sdk.exception.LiInitializationException;
 import lithium.community.android.sdk.exception.LiRestResponseException;
 import lithium.community.android.sdk.manager.LiSDKManager;
 import lithium.community.android.sdk.model.LiBaseModelImpl;
@@ -63,6 +63,7 @@ import lithium.community.android.sdk.utils.LiCoreSDKConstants;
 import lithium.community.android.sdk.utils.LiCoreSDKUtils;
 import lithium.community.android.sdk.utils.LiImageUtils;
 import lithium.community.android.sdk.utils.LiUriUtils;
+import lithium.community.android.sdk.utils.MessageConstants;
 import okhttp3.Call;
 import okhttp3.Callback;
 import okhttp3.ConnectionSpec;
@@ -85,51 +86,58 @@ import static lithium.community.android.sdk.utils.LiCoreSDKConstants.LI_VISIT_OR
 import static lithium.community.android.sdk.utils.LiCoreSDKUtils.addLSIRequestHeaders;
 
 /**
- * Base rest client. Provides all the generic request response rest call implementation.
+ * Base rest client. Provides all the generic REST implementation.
  */
 public abstract class LiRestClient {
 
     public static final String TOKEN_REFRESH_TAG = "TOKEN_REFRESH_TAG";
     public static final int SERVER_TIMEOUT = 1000;
     private final Gson gson;
+    private LiSDKManager sdkManager;
     private OkHttpClient httpClient;
 
-    public LiRestClient() throws LiRestResponseException {
+    /**
+     * Default public constructor.
+     *
+     * @param manager the Li SDK Manager
+     * @throws LiInitializationException if Rest Client failed to initialize successfully.
+     */
+    public LiRestClient(@NonNull LiSDKManager manager) throws LiInitializationException {
+        this.sdkManager = LiCoreSDKUtils.checkNotNull(manager, MessageConstants.wasNull("manager"));
+
         final GsonBuilder gsonBuilder = new GsonBuilder();
-        gsonBuilder.registerTypeAdapter(LiBaseModelImpl.LiDateInstant.class,
-                new JsonDeserializer<LiBaseModelImpl.LiDateInstant>() {
-                    @Override
-                    public LiBaseModelImpl.LiDateInstant deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context)
-                            throws JsonParseException {
-                        LiBaseModelImpl.LiDateInstant dateInstant = new LiBaseModelImpl.LiDateInstant();
-                        dateInstant.setValue(json.getAsString());
-                        return dateInstant;
-                    }
-                })
-                .registerTypeAdapter(LiBaseModelImpl.LiString.class, new JsonDeserializer<LiBaseModelImpl.LiString>() {
-                    @Override
-                    public LiBaseModelImpl.LiString deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
-                        LiBaseModelImpl.LiString liString = new LiBaseModelImpl.LiString();
-                        liString.setValue(json.getAsString());
-                        return liString;
-                    }
-                })
-                .registerTypeAdapter(LiBaseModelImpl.LiBoolean.class, new JsonDeserializer<LiBaseModelImpl.LiBoolean>() {
-                    @Override
-                    public LiBaseModelImpl.LiBoolean deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
-                        LiBaseModelImpl.LiBoolean liBoolean = new LiBaseModelImpl.LiBoolean();
-                        liBoolean.setValue(json.getAsBoolean());
-                        return liBoolean;
-                    }
-                })
-                .registerTypeAdapter(LiBaseModelImpl.LiInt.class, new JsonDeserializer<LiBaseModelImpl.LiInt>() {
-                    @Override
-                    public LiBaseModelImpl.LiInt deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
-                        LiBaseModelImpl.LiInt liBoolean = new LiBaseModelImpl.LiInt();
-                        liBoolean.setValue(json.getAsLong());
-                        return liBoolean;
-                    }
-                });
+        gsonBuilder.registerTypeAdapter(LiBaseModelImpl.LiDateInstant.class, new JsonDeserializer<LiBaseModelImpl.LiDateInstant>() {
+            @Override
+            public LiBaseModelImpl.LiDateInstant deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+                LiBaseModelImpl.LiDateInstant dateInstant = new LiBaseModelImpl.LiDateInstant();
+                dateInstant.setValue(json.getAsString());
+                return dateInstant;
+            }
+        });
+        gsonBuilder.registerTypeAdapter(LiBaseModelImpl.LiString.class, new JsonDeserializer<LiBaseModelImpl.LiString>() {
+            @Override
+            public LiBaseModelImpl.LiString deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+                LiBaseModelImpl.LiString liString = new LiBaseModelImpl.LiString();
+                liString.setValue(json.getAsString());
+                return liString;
+            }
+        });
+        gsonBuilder.registerTypeAdapter(LiBaseModelImpl.LiBoolean.class, new JsonDeserializer<LiBaseModelImpl.LiBoolean>() {
+            @Override
+            public LiBaseModelImpl.LiBoolean deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+                LiBaseModelImpl.LiBoolean liBoolean = new LiBaseModelImpl.LiBoolean();
+                liBoolean.setValue(json.getAsBoolean());
+                return liBoolean;
+            }
+        });
+        gsonBuilder.registerTypeAdapter(LiBaseModelImpl.LiInt.class, new JsonDeserializer<LiBaseModelImpl.LiInt>() {
+            @Override
+            public LiBaseModelImpl.LiInt deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+                LiBaseModelImpl.LiInt liBoolean = new LiBaseModelImpl.LiInt();
+                liBoolean.setValue(json.getAsLong());
+                return liBoolean;
+            }
+        });
 
         gson = gsonBuilder.create();
         ConnectionSpec connectionSpec = new ConnectionSpec.Builder(ConnectionSpec.MODERN_TLS)
@@ -167,9 +175,19 @@ public abstract class LiRestClient {
                     .sslSocketFactory(sslSocketFactory, trustManager);
             this.httpClient = builder.build();
         } catch (Exception e) {
-            throw LiRestResponseException.networkError(e.getMessage());
+            throw new LiInitializationException(LiRestClient.class.getSimpleName(), e);
         }
+    }
 
+    /**
+     * Deprecated public constructor.
+     *
+     * @throws LiInitializationException if Rest Client failed to initialize successfully.
+     * @throws IllegalArgumentException  if the SDK is not initialized.
+     * @deprecated Use {@link #LiRestClient(LiSDKManager)} instead
+     */
+    public LiRestClient() throws LiInitializationException {
+        this(LiCoreSDKUtils.checkNotNull(LiSDKManager.getInstance(), MessageConstants.wasNull("Li SDK Manager")));
     }
 
     public Gson getGson() {
@@ -179,18 +197,18 @@ public abstract class LiRestClient {
     /**
      * Makes Sync Network call.
      *
-     * @param baseRestRequest {@link LiBaseRestRequest}
-     * @return LiBaseResponse {@link LiBaseResponse}
-     * @throws LiRestResponseException {@link LiRestResponseException}
+     * @param baseRestRequest A REST request.
+     * @return LiBaseResponse A valid response.
+     * @throws LiRestResponseException if the request failed or the response was invalid.
      */
     public LiBaseResponse processSync(@NonNull LiBaseRestRequest baseRestRequest) throws LiRestResponseException {
-        LiCoreSDKUtils.checkNotNull(baseRestRequest);
-        if (baseRestRequest.isAuthenticatedRequest() && LiSDKManager.getInstance().isUserLoggedIn()) {
-            if (LiSDKManager.getInstance().getNeedsTokenRefresh()) {
-                Log.d(TOKEN_REFRESH_TAG, "Refresh Token expired on device, fetching again: " + LiSDKManager.getInstance().getNewAuthToken());
-                LiTokenResponse liTokenResponse = new LiAuthServiceImpl(baseRestRequest.getContext()).performSyncRefreshTokenRequest();
-                LiSDKManager.getInstance().persistAuthState(baseRestRequest.getContext(), liTokenResponse);
-                Log.d(TOKEN_REFRESH_TAG, "Fetched new refresh token: " + LiSDKManager.getInstance().getNewAuthToken());
+        LiCoreSDKUtils.checkNotNull(baseRestRequest, MessageConstants.wasNull("baseRestRequest"));
+        if (baseRestRequest.isAuthenticatedRequest() && sdkManager.isUserLoggedIn()) {
+            if (sdkManager.getNeedsTokenRefresh()) {
+                Log.d(TOKEN_REFRESH_TAG, "Refresh Token expired on device, fetching again: " + sdkManager.getNewAuthToken());
+                LiTokenResponse liTokenResponse = new LiAuthServiceImpl(baseRestRequest.getContext(), sdkManager).performSyncRefreshTokenRequest();
+                sdkManager.persistAuthState(baseRestRequest.getContext(), liTokenResponse);
+                Log.d(TOKEN_REFRESH_TAG, "Fetched new refresh token: " + sdkManager.getNewAuthToken());
             }
         }
 
@@ -225,26 +243,26 @@ public abstract class LiRestClient {
     /**
      * Makes Async Network call.
      *
-     * @param baseRestRequest {@link LiBaseRestRequest}
-     * @param callback        {@link LiAsyncRequestCallback}
+     * @param baseRestRequest A REST request.
+     * @param callback        A callback to be called once the request is completed.
      */
     public void processAsync(@NonNull final LiBaseRestRequest baseRestRequest, @NonNull final LiAsyncRequestCallback callback) {
-        if (baseRestRequest.isAuthenticatedRequest() && LiSDKManager.getInstance().isUserLoggedIn()) {
-            if (LiSDKManager.getInstance().getNeedsTokenRefresh()) {
+        if (baseRestRequest.isAuthenticatedRequest() && sdkManager.isUserLoggedIn()) {
+            if (sdkManager.getNeedsTokenRefresh()) {
                 try {
-                    Log.d(TOKEN_REFRESH_TAG, "Refresh Token expired on device, fetching again: " + LiSDKManager.getInstance().getNewAuthToken());
-                    LiSDKManager.getInstance().fetchFreshAccessToken(baseRestRequest.getContext(), new LiAuthServiceImpl.FreshTokenCallBack() {
+                    Log.d(TOKEN_REFRESH_TAG, "Refresh Token expired on device, fetching again: " + sdkManager.getNewAuthToken());
+                    sdkManager.fetchFreshAccessToken(baseRestRequest.getContext(), new LiAuthServiceImpl.FreshTokenCallBack() {
                         @Override
                         public void onFreshTokenFetched(boolean isFetched) {
                             if (isFetched) {
-                                Log.d(TOKEN_REFRESH_TAG, "Fetched new refresh token: " + LiSDKManager.getInstance().getNewAuthToken());
+                                Log.d(TOKEN_REFRESH_TAG, "Fetched new refresh token: " + sdkManager.getNewAuthToken());
                                 enqueueCall(baseRestRequest, callback);
                             } else {
                                 callback.onError(LiRestResponseException.networkError("Could not refresh token"));
                             }
                         }
                     });
-                } catch (URISyntaxException | LiRestResponseException e) {
+                } catch (LiRestResponseException e) {
                     callback.onError(e);
                 }
             } else {
@@ -309,18 +327,18 @@ public abstract class LiRestClient {
      */
     public void uploadImageProcessAsync(@NonNull final LiBaseRestRequest baseRestRequest, @NonNull final LiAsyncRequestCallback callback,
                                         final String imagePath, final String imageName, final String requestBody) {
-        if (baseRestRequest.isAuthenticatedRequest() && LiSDKManager.getInstance().isUserLoggedIn()) {
-            if (LiSDKManager.getInstance().getNeedsTokenRefresh()) {
+        if (baseRestRequest.isAuthenticatedRequest() && sdkManager.isUserLoggedIn()) {
+            if (sdkManager.getNeedsTokenRefresh()) {
                 try {
-                    Log.d(TOKEN_REFRESH_TAG, "Refresh Token expired on device, fetching again: " + LiSDKManager.getInstance().getNewAuthToken());
-                    LiSDKManager.getInstance().fetchFreshAccessToken(baseRestRequest.getContext(), new LiAuthServiceImpl.FreshTokenCallBack() {
+                    Log.d(TOKEN_REFRESH_TAG, "Refresh Token expired on device, fetching again: " + sdkManager.getNewAuthToken());
+                    sdkManager.fetchFreshAccessToken(baseRestRequest.getContext(), new LiAuthServiceImpl.FreshTokenCallBack() {
                         @Override
                         public void onFreshTokenFetched(boolean isFetched) {
-                            Log.d(TOKEN_REFRESH_TAG, "Fetched new refresh token: " + LiSDKManager.getInstance().getNewAuthToken());
+                            Log.d(TOKEN_REFRESH_TAG, "Fetched new refresh token: " + sdkManager.getNewAuthToken());
                             uploadEnqueueCall(baseRestRequest, callback, imagePath, imageName, requestBody);
                         }
                     });
-                } catch (URISyntaxException | LiRestResponseException e) {
+                } catch (LiRestResponseException e) {
                     callback.onError(e);
                 }
             } else {
@@ -357,7 +375,7 @@ public abstract class LiRestClient {
         }
 
         Uri.Builder uriBuilder = new Uri.Builder().scheme("https");
-        String proxyHost = LiSDKManager.getInstance().getProxyHost();
+        String proxyHost = sdkManager.getProxyHost();
 
         uriBuilder.authority(proxyHost);
         uriBuilder.appendEncodedPath(baseRestRequest.getPath());
@@ -441,9 +459,9 @@ public abstract class LiRestClient {
         String requestUrl = response.header("http.request");
         if (requestUrl != null && requestUrl.contains("/beacon") && response.code() == LiCoreSDKConstants.HTTP_CODE_SUCCESSFUL) {
             String visitorLastIssueTime = response.header(LiRequestHeaderConstants.LI_REQUEST_VISIT_LAST_ISSUE_TIME);
-            LiSDKManager.getInstance().putInSecuredPreferences(baseRestRequest.getContext(), LI_VISIT_LAST_ISSUE_TIME_KEY, visitorLastIssueTime);
+            sdkManager.putInSecuredPreferences(baseRestRequest.getContext(), LI_VISIT_LAST_ISSUE_TIME_KEY, visitorLastIssueTime);
             String visitOriginTime = response.header(LiRequestHeaderConstants.LI_REQUEST_VISIT_ORIGIN_TIME);
-            LiSDKManager.getInstance().putInSecuredPreferences(baseRestRequest.getContext(), LI_VISIT_ORIGIN_TIME_KEY, visitOriginTime);
+            sdkManager.putInSecuredPreferences(baseRestRequest.getContext(), LI_VISIT_ORIGIN_TIME_KEY, visitOriginTime);
         }
     }
 
@@ -455,7 +473,7 @@ public abstract class LiRestClient {
      */
     protected Request buildRequest(LiBaseRestRequest baseRestRequest) {
         Uri.Builder uriBuilder = new Uri.Builder().scheme("https");
-        uriBuilder.authority(LiSDKManager.getInstance().getProxyHost());
+        uriBuilder.authority(sdkManager.getProxyHost());
         uriBuilder.appendEncodedPath(baseRestRequest.getPath());
         if (baseRestRequest.getQueryParams() != null) {
             for (String param : baseRestRequest.getQueryParams().keySet()) {
@@ -480,33 +498,33 @@ public abstract class LiRestClient {
     @NonNull
     private Request.Builder buildRequestHeaders(Context context, Request.Builder requestBuilder) {
 
-        if (!TextUtils.isEmpty(LiSDKManager.getInstance().getNewAuthToken())) {
-            requestBuilder.header(LiAuthConstants.AUTHORIZATION, LiAuthConstants.BEARER + LiSDKManager.getInstance().getNewAuthToken());
+        if (!TextUtils.isEmpty(sdkManager.getNewAuthToken())) {
+            requestBuilder.header(LiAuthConstants.AUTHORIZATION, LiAuthConstants.BEARER + sdkManager.getNewAuthToken());
         }
         requestBuilder.header(LiRequestHeaderConstants.LI_REQUEST_CONTENT_TYPE, "application/json");
-        requestBuilder.header(LiRequestHeaderConstants.LI_REQUEST_CLIENT_ID, LiSDKManager.getInstance().getLiAppCredentials().getClientKey());
+        requestBuilder.header(LiRequestHeaderConstants.LI_REQUEST_CLIENT_ID, sdkManager.getLiAppCredentials().getClientKey());
         addLSIRequestHeaders(context, requestBuilder);
 
         return requestBuilder;
     }
 
-    @NonNull
-    @Deprecated
     /**
      * request header key "lia-sdk-app-info"
      */
+    @NonNull
+    @Deprecated
     private String buildLSIHeaderString(Context context) {
         JsonObject headerJson = new JsonObject();
-        headerJson.addProperty("client_name", LiSDKManager.getInstance().getLiAppCredentials().getClientAppName());
+        headerJson.addProperty("client_name", sdkManager.getLiAppCredentials().getClientName());
         headerJson.addProperty("client_type", "android");
-        headerJson.addProperty("client_id", LiSDKManager.getInstance().getLiAppCredentials().getClientKey());
+        headerJson.addProperty("client_id", sdkManager.getLiAppCredentials().getClientKey());
         headerJson.addProperty("device_code", android.os.Build.DEVICE);
         headerJson.addProperty("device_model", android.os.Build.MODEL);
         headerJson.addProperty("device_id", Settings.Secure.getString(context.getContentResolver(), Settings.Secure.ANDROID_ID));
         headerJson.addProperty("device_api_level", android.os.Build.VERSION.SDK_INT);
         String userId = null;
-        if (LiSDKManager.getInstance().getLoggedInUser() != null) {
-            userId = LiSDKManager.getInstance().getLoggedInUser().getLoginId();
+        if (sdkManager.getLoggedInUser() != null) {
+            userId = sdkManager.getLoggedInUser().getLoginId();
         }
         headerJson.addProperty("user_id", userId);
         return headerJson.toString();
@@ -591,14 +609,14 @@ public abstract class LiRestClient {
                     }
                     if (httpCode == HTTP_CODE_UNAUTHORIZED || httpCode == HTTP_CODE_FORBIDDEN) {
                         try {
-                            LiTokenResponse liTokenResponse = new LiAuthServiceImpl(context).performSyncRefreshTokenRequest();
-                            LiSDKManager.getInstance().persistAuthState(context, liTokenResponse);
-                            LiSDKManager.getInstance().persistAuthState(context, liTokenResponse);
+                            LiTokenResponse liTokenResponse = new LiAuthServiceImpl(context, sdkManager).performSyncRefreshTokenRequest();
+                            sdkManager.persistAuthState(context, liTokenResponse);
+                            sdkManager.persistAuthState(context, liTokenResponse);
 
                             request = request.newBuilder().removeHeader(LiAuthConstants.AUTHORIZATION).build();
 
-                            request = request.newBuilder().addHeader(LiAuthConstants.AUTHORIZATION,
-                                    LiAuthConstants.BEARER + LiSDKManager.getInstance().getNewAuthToken()).build();
+                            request = request.newBuilder().addHeader(LiAuthConstants.AUTHORIZATION, LiAuthConstants.BEARER + sdkManager.getNewAuthToken())
+                                    .build();
                         } catch (LiRestResponseException e) {
                             Log.e(LOG_TAG, "Error making rest call for refresh token", e);
                         }

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/rest/LiRestClient.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/rest/LiRestClient.java
@@ -502,7 +502,7 @@ public abstract class LiRestClient {
             requestBuilder.header(LiAuthConstants.AUTHORIZATION, LiAuthConstants.BEARER + sdkManager.getNewAuthToken());
         }
         requestBuilder.header(LiRequestHeaderConstants.LI_REQUEST_CONTENT_TYPE, "application/json");
-        requestBuilder.header(LiRequestHeaderConstants.LI_REQUEST_CLIENT_ID, sdkManager.getLiAppCredentials().getClientKey());
+        requestBuilder.header(LiRequestHeaderConstants.LI_REQUEST_CLIENT_ID, sdkManager.getCredentials().getClientKey());
         addLSIRequestHeaders(context, requestBuilder);
 
         return requestBuilder;
@@ -515,9 +515,9 @@ public abstract class LiRestClient {
     @Deprecated
     private String buildLSIHeaderString(Context context) {
         JsonObject headerJson = new JsonObject();
-        headerJson.addProperty("client_name", sdkManager.getLiAppCredentials().getClientName());
+        headerJson.addProperty("client_name", sdkManager.getCredentials().getClientName());
         headerJson.addProperty("client_type", "android");
-        headerJson.addProperty("client_id", sdkManager.getLiAppCredentials().getClientKey());
+        headerJson.addProperty("client_id", sdkManager.getCredentials().getClientKey());
         headerJson.addProperty("device_code", android.os.Build.DEVICE);
         headerJson.addProperty("device_model", android.os.Build.MODEL);
         headerJson.addProperty("device_id", Settings.Secure.getString(context.getContentResolver(), Settings.Secure.ANDROID_ID));
@@ -610,7 +610,6 @@ public abstract class LiRestClient {
                     if (httpCode == HTTP_CODE_UNAUTHORIZED || httpCode == HTTP_CODE_FORBIDDEN) {
                         try {
                             LiTokenResponse liTokenResponse = new LiAuthServiceImpl(context, sdkManager).performSyncRefreshTokenRequest();
-                            sdkManager.persistAuthState(context, liTokenResponse);
                             sdkManager.persistAuthState(context, liTokenResponse);
 
                             request = request.newBuilder().removeHeader(LiAuthConstants.AUTHORIZATION).build();

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/rest/LiRestv2Client.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/rest/LiRestv2Client.java
@@ -24,7 +24,9 @@ import com.google.gson.JsonObject;
 
 import java.io.IOException;
 
+import lithium.community.android.sdk.exception.LiInitializationException;
 import lithium.community.android.sdk.exception.LiRestResponseException;
+import lithium.community.android.sdk.manager.LiSDKManager;
 import lithium.community.android.sdk.utils.LiCoreSDKUtils;
 import lithium.community.android.sdk.utils.MessageConstants;
 
@@ -35,8 +37,8 @@ public class LiRestv2Client extends LiRestClient {
 
     private static final String LOG_TAG = "LiRestv2Client";
 
-    private LiRestv2Client() throws LiRestResponseException {
-        super();
+    private LiRestv2Client(@NonNull LiSDKManager manager) throws LiInitializationException {
+        super(manager);
     }
 
     /**
@@ -45,7 +47,7 @@ public class LiRestv2Client extends LiRestClient {
      * @return Instance of this class.
      */
     public static LiRestv2Client getInstance() {
-        return LiRestv2ClientInitializer.LI_RESTV_2_CLIENT;
+        return LiRestV2ClientInitializer.LI_RESTV_2_CLIENT;
     }
 
     /**
@@ -104,7 +106,9 @@ public class LiRestv2Client extends LiRestClient {
         } catch (LiRestResponseException e) {
             callBack.onError(e);
         }
-        super.processAsync(restV2Request, callBack);
+        if (restV2Request != null) {
+            super.processAsync(restV2Request, callBack);
+        }
     }
 
     /**
@@ -172,18 +176,19 @@ public class LiRestv2Client extends LiRestClient {
     /**
      * Initializer for LiRestV2Client.
      */
-    private static class LiRestv2ClientInitializer {
+    private static class LiRestV2ClientInitializer {
+
         private static final LiRestv2Client LI_RESTV_2_CLIENT;
 
         static {
-            LiRestv2Client tempLiRestv2Client = null;
+            LiRestv2Client instance;
             try {
-                tempLiRestv2Client = new LiRestv2Client();
-            } catch (Exception e) {
-                Log.e(LOG_TAG, "Failed to initialized LiRestV2Client: " + e);
+                instance = new LiRestv2Client(LiCoreSDKUtils.checkNotNull(LiSDKManager.getInstance(), MessageConstants.wasNull("SDK Manager")));
+            } catch (LiInitializationException e) {
+                instance = null;
+                e.printStackTrace();
             }
-            LI_RESTV_2_CLIENT = tempLiRestv2Client;
+            LI_RESTV_2_CLIENT = instance;
         }
-
     }
 }

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/utils/LiCoreSDKUtils.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/utils/LiCoreSDKUtils.java
@@ -469,10 +469,15 @@ public class LiCoreSDKUtils {
     }
 
     public static void addLSIRequestHeaders(@NonNull Context context, Request.Builder builder) {
-        builder.header(LiRequestHeaderConstants.LI_REQUEST_APPLICATION_IDENTIFIER,
-                LiSDKManager.getInstance().getLiAppCredentials().getClientAppName());
+        addLSIRequestHeaders(context, checkNotNull(LiSDKManager.getInstance(), MessageConstants.wasNull("Li SDK Manager")), builder);
+    }
+
+    public static void addLSIRequestHeaders(@NonNull Context context, @NonNull LiSDKManager manager, @NonNull Request.Builder builder) {
+        checkNotNull(context, MessageConstants.wasNull("context"));
+        checkNotNull(manager, MessageConstants.wasNull("manager"));
+        checkNotNull(builder, MessageConstants.wasNull("builder"));
+        builder.header(LiRequestHeaderConstants.LI_REQUEST_APPLICATION_IDENTIFIER, manager.getLiAppCredentials().getClientName());
         builder.header(LiRequestHeaderConstants.LI_REQUEST_APPLICATION_VERSION, BuildConfig.li_sdk_core_version);
-        builder.header(LiRequestHeaderConstants.LI_REQUEST_VISITOR_ID,
-                LiSDKManager.getInstance().getFromSecuredPreferences(context, LiCoreSDKConstants.LI_VISITOR_ID));
+        builder.header(LiRequestHeaderConstants.LI_REQUEST_VISITOR_ID, manager.getFromSecuredPreferences(context, LiCoreSDKConstants.LI_VISITOR_ID));
     }
 }

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/utils/LiCoreSDKUtils.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/utils/LiCoreSDKUtils.java
@@ -476,7 +476,7 @@ public class LiCoreSDKUtils {
         checkNotNull(context, MessageConstants.wasNull("context"));
         checkNotNull(manager, MessageConstants.wasNull("manager"));
         checkNotNull(builder, MessageConstants.wasNull("builder"));
-        builder.header(LiRequestHeaderConstants.LI_REQUEST_APPLICATION_IDENTIFIER, manager.getLiAppCredentials().getClientName());
+        builder.header(LiRequestHeaderConstants.LI_REQUEST_APPLICATION_IDENTIFIER, manager.getCredentials().getClientName());
         builder.header(LiRequestHeaderConstants.LI_REQUEST_APPLICATION_VERSION, BuildConfig.li_sdk_core_version);
         builder.header(LiRequestHeaderConstants.LI_REQUEST_VISITOR_ID, manager.getFromSecuredPreferences(context, LiCoreSDKConstants.LI_VISITOR_ID));
     }

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/utils/LiImageUtils.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/utils/LiImageUtils.java
@@ -48,7 +48,7 @@ public class LiImageUtils {
         Bitmap compressedBitmap = getCompressedBitmap(filePath, reqWidth, reqHeight);
 
         String fileDirectory = String.valueOf(android.os.Environment.getExternalStorageDirectory()) + File.separator
-                + LiSDKManager.getInstance().getLiAppCredentials().getTenantId() + "-community" + File.separator;
+                + LiSDKManager.getInstance().getCredentials().getTenantId() + "-community" + File.separator;
         final File communityRoot = new File(fileDirectory);
         communityRoot.mkdirs();
         File compressedFile = new File(fileDirectory + "/" + fileName);

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/utils/LiUUIDUtils.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/utils/LiUUIDUtils.java
@@ -22,16 +22,17 @@ import java.util.UUID;
  * On LIA side fetching is done bu UUID, so this class converts UUID to Client Id.
  */
 public final class LiUUIDUtils {
+
     private LiUUIDUtils() {
     }
 
     /**
      * Converts a {@link UUID} to a byte array.
      *
-     * @param uuid
+     * @param uuid The UUID to convert.
      * @return the UUID byte array.
      */
-    public static final byte[] toBytes(UUID uuid) {
+    public static byte[] toBytes(UUID uuid) {
         long msb = uuid.getMostSignificantBits();
         long lsb = uuid.getLeastSignificantBits();
         byte[] buffer = new byte[16];
@@ -47,15 +48,15 @@ public final class LiUUIDUtils {
     }
 
     /**
-     * Converts a {@link UUID} String to a byte array.
+     * Converts a string to UUID and returns it as a byte array.
      *
-     * @param uuidString
-     * @return the UUID byte array.
+     * @param input the input string.
+     * @return the byte array if the UUID.
      * @throws IllegalArgumentException if name does not conform to the string representation as described in
      *                                  {@link UUID#toString}.
      */
-    public static final byte[] toBytes(String uuidString) {
-        UUID uuid = UUID.fromString(uuidString);
+    public static byte[] toBytes(String input) {
+        UUID uuid = UUID.fromString(input);
 
         return toBytes(uuid);
     }
@@ -78,5 +79,4 @@ public final class LiUUIDUtils {
 
         return new UUID(msb, lsb);
     }
-
 }


### PR DESCRIPTION
`LiSDKManager` is designed as a singleton, its dependents reference if using its `getInstance()` method. Singletons make unit testing difficult and since the `getInstance()` is marked as `Nullable` there will be a lot of `null` checks for every usage. 
Instead, the `LiSDKManager` and other such singletons should be injected into components via constructor arguments and used directly.

In addition, this change request also removes usages of deprecated APIs, adds more `null` checks, add JavaDoc and marks some more APIs as deprecated to promote better design.