### PR TITLE
Refactor initialization flows of internal components

### DIFF
--- a/li-android-sdk-core/build.gradle
+++ b/li-android-sdk-core/build.gradle
@@ -27,8 +27,8 @@ properties.load(project.rootProject.file('local.properties').newDataInputStream(
 project.ext.set('groupId', 'lithium.community.android.sdk')
 project.ext.set('artifactId', 'li-android-sdk-core')
 
-project.ext.set('versionCode', 120500)
-project.ext.set('versionName', '1.2.5')
+project.ext.set('versionCode', 120611)
+project.ext.set('versionName', '1.2.6')
 
 project.ext.set('repositoryName', 'li-android-sdk')
 project.ext.set('localReleaseDest', "${buildDir}/release/${project.ext.versionName}")

--- a/li-android-sdk-core/build.gradle
+++ b/li-android-sdk-core/build.gradle
@@ -86,6 +86,7 @@ unMock {
     keep "android.database.CrossProcessCursor"
     keep "android.location.Location"
     keep "android.net.Uri"
+    keep "javax.net.ssl"
     keepStartingWith "android.database.MatrixCursor"
     keepStartingWith "android.text.TextUtils"
     keepStartingWith "android.util."
@@ -123,6 +124,7 @@ dependencies {
     testCompile "org.mockito:mockito-all:$project.ext.mockitoVersion"
     testCompile "org.powermock:powermock-module-junit4:$project.ext.powerMockito"
     testCompile "org.powermock:powermock-api-mockito:$project.ext.powerMockito"
+    testCompile "com.squareup.okhttp3:mockwebserver:$project.ext.okhttpVersion"
     testCompile "com.squareup.assertj:assertj-android:$project.ext.assertjAndroidVersion"
 }
 

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/api/LiBaseClient.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/api/LiBaseClient.java
@@ -66,8 +66,8 @@ abstract class LiBaseClient implements LiClient {
         this.liRestv2Client = LiRestv2Client.getInstance();
     }
 
-    public LiBaseClient(Context context, String basePath, String type, String querySettingsType,
-            Class<? extends LiBaseModel> responseClass, RequestType requestType) throws LiRestResponseException {
+    public LiBaseClient(Context context, String basePath, String type, String querySettingsType, Class<? extends LiBaseModel> responseClass,
+                        RequestType requestType) throws LiRestResponseException {
         this.context = context;
         this.type = type;
         this.querySettingsType = querySettingsType;
@@ -78,32 +78,23 @@ abstract class LiBaseClient implements LiClient {
     }
 
 
-    public LiBaseClient(Context context, String type, String querySettingsType,
-            Class<? extends LiBaseModel> responseClass, RequestType requestType) throws LiRestResponseException {
+    public LiBaseClient(Context context, String type, String querySettingsType, Class<? extends LiBaseModel> responseClass, RequestType requestType)
+            throws LiRestResponseException {
         this.context = context;
         this.type = type;
         this.querySettingsType = querySettingsType;
-        String tenant = LiSDKManager.getInstance().getTenant();
-        if (tenant == null) {
-            tenant = LiSDKManager.getInstance().getCredentials().getTenantId();
-        }
-        this.basePath = String.format(LiAuthConstants.API_PROXY_DEFAULT_SEARCH_BASE_PATH, tenant);
+        this.basePath = String.format(LiAuthConstants.API_PROXY_DEFAULT_SEARCH_BASE_PATH, LiSDKManager.getInstance().getTenantId());
         this.responseClass = responseClass;
         this.liRestv2Client = LiRestv2Client.getInstance();
         this.requestType = requestType;
     }
 
-    public LiBaseClient(Context context, String type, String querySettingsType,
-            Class<? extends LiBaseModel> responseClass, RequestType requestType,
-            String pathParam) throws LiRestResponseException {
+    public LiBaseClient(Context context, String type, String querySettingsType, Class<? extends LiBaseModel> responseClass, RequestType requestType,
+                        String pathParam) throws LiRestResponseException {
         this.context = context;
         this.type = type;
         this.querySettingsType = querySettingsType;
-        String tenant = LiSDKManager.getInstance().getTenant();
-        if (tenant == null) {
-            tenant = LiSDKManager.getInstance().getCredentials().getTenantId();
-        }
-        this.basePath = String.format(LiAuthConstants.API_PROXY_DEFAULT_GENERIC_BASE_PATH, tenant, pathParam);
+        this.basePath = String.format(LiAuthConstants.API_PROXY_DEFAULT_GENERIC_BASE_PATH, LiSDKManager.getInstance().getTenantId(), pathParam);
         this.responseClass = responseClass;
         this.liRestv2Client = LiRestv2Client.getInstance();
         this.requestType = requestType;
@@ -153,13 +144,11 @@ abstract class LiBaseClient implements LiClient {
             this.liRestV2Request.setPath(basePath);
             final LiAsyncRequestCallback callback = new LiAsyncRequestCallback<LiBaseResponse>() {
                 @Override
-                public void onSuccess(LiBaseRestRequest request,
-                        LiBaseResponse response) throws LiRestResponseException {
+                public void onSuccess(LiBaseRestRequest request, LiBaseResponse response) throws LiRestResponseException {
                     if (null != response) {
                         if (response.getHttpCode() == LiCoreSDKConstants.HTTP_CODE_SUCCESSFUL) {
                             if (requestType.equals(RequestType.GET)) {
-                                liAsyncRequestCallback.onSuccess(request,
-                                        new LiGetClientResponse(response, type, responseClass, getGson()));
+                                liAsyncRequestCallback.onSuccess(request, new LiGetClientResponse(response, type, responseClass, getGson()));
                             } else if (requestType.equals(RequestType.DELETE)) {
                                 liAsyncRequestCallback.onSuccess(request, new LiDeleteClientResponse(response));
                             } else if (requestType.equals(RequestType.PUT)) {
@@ -203,13 +192,11 @@ abstract class LiBaseClient implements LiClient {
             String requestBody = getRequestBody();
             final LiAsyncRequestCallback callback = new LiAsyncRequestCallback<LiBaseResponse>() {
                 @Override
-                public void onSuccess(LiBaseRestRequest request,
-                        LiBaseResponse response) throws LiRestResponseException {
+                public void onSuccess(LiBaseRestRequest request, LiBaseResponse response) throws LiRestResponseException {
                     if (null != response) {
                         if (response.getHttpCode() == LiCoreSDKConstants.HTTP_CODE_SUCCESSFUL) {
                             if (requestType.equals(RequestType.GET)) {
-                                liAsyncRequestCallback.onSuccess(request,
-                                        new LiGetClientResponse(response, type, responseClass, getGson()));
+                                liAsyncRequestCallback.onSuccess(request, new LiGetClientResponse(response, type, responseClass, getGson()));
                             } else {
                                 liAsyncRequestCallback.onSuccess(request, new LiPostClientResponse(response));
                             }
@@ -299,7 +286,6 @@ abstract class LiBaseClient implements LiClient {
     /**
      * Enum to classify Request Type
      */
-
     protected enum RequestType {
         GET, POST, DELETE, PUT;
     }

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/auth/LiAppCredentials.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/auth/LiAppCredentials.java
@@ -59,6 +59,9 @@ public final class LiAppCredentials {
     private final Uri communityUri;
 
     @NonNull
+    private final String deviceId;
+
+    @NonNull
     private final Uri apiGatewayHost;
 
     @NonNull
@@ -79,15 +82,19 @@ public final class LiAppCredentials {
      * @param tenantId       tenant ID of the community.
      * @param communityURL   The LIA community's URL. (scheme + host)
      * @param apiGatewayHost API gateway host. (host)
+     * @param deviceId       A unique static identifier for this device. Suggested Firebase instance id.
      */
     public LiAppCredentials(@NonNull String clientName, @NonNull String clientKey, @NonNull String clientSecret,
-                            @NonNull String tenantId, @NonNull String communityURL, @NonNull String apiGatewayHost) {
+                            @NonNull String tenantId, @NonNull String communityURL, @NonNull String apiGatewayHost,
+                            @NonNull String deviceId) {
         this.clientName = LiCoreSDKUtils.checkNullOrNotEmpty(clientName, MessageConstants.wasEmpty("clientName"));
         this.clientKey = LiCoreSDKUtils.checkNullOrNotEmpty(clientKey, MessageConstants.wasEmpty("clientKey"));
         this.clientSecret = LiCoreSDKUtils.checkNullOrNotEmpty(clientSecret, MessageConstants.wasEmpty("clientSecret"));
         this.tenantId = LiCoreSDKUtils.checkNullOrNotEmpty(tenantId, MessageConstants.wasEmpty("tenantId"));
 
         this.communityUri = Uri.parse(LiCoreSDKUtils.checkNullOrNotEmpty(communityURL, MessageConstants.wasEmpty("communityURL")));
+        this.deviceId = LiCoreSDKUtils.checkNullOrNotEmpty(deviceId, MessageConstants.wasEmpty("deviceId"));
+
         this.apiGatewayHost = Uri.parse(LiCoreSDKUtils.checkNullOrNotEmpty(apiGatewayHost, MessageConstants.wasEmpty("apiGatewayHost")));
 
         this.redirectUri = buildRedirectUri(communityUri);
@@ -122,6 +129,11 @@ public final class LiAppCredentials {
     @NonNull
     public Uri getCommunityUri() {
         return communityUri;
+    }
+
+    @NonNull
+    public String getDeviceId() {
+        return deviceId;
     }
 
     @NonNull
@@ -177,8 +189,9 @@ public final class LiAppCredentials {
         LiAppCredentials that = (LiAppCredentials) o;
 
         return clientName.equals(that.clientName) && tenantId.equals(that.tenantId) && clientKey.equals(that.clientKey)
-                && clientSecret.equals(that.clientSecret) && communityUri.equals(that.communityUri) && apiGatewayHost.equals(that.apiGatewayHost)
-                && authorizeUri.equals(that.authorizeUri) && redirectUri.equals(that.redirectUri) && ssoAuthorizeUri.equals(that.ssoAuthorizeUri);
+                && clientSecret.equals(that.clientSecret) && communityUri.equals(that.communityUri) && deviceId.equals(that.deviceId)
+                && apiGatewayHost.equals(that.apiGatewayHost) && authorizeUri.equals(that.authorizeUri) && redirectUri.equals(that.redirectUri)
+                && ssoAuthorizeUri.equals(that.ssoAuthorizeUri);
     }
 
     @Override
@@ -188,6 +201,7 @@ public final class LiAppCredentials {
         result = 31 * result + clientKey.hashCode();
         result = 31 * result + clientSecret.hashCode();
         result = 31 * result + communityUri.hashCode();
+        result = 31 * result + deviceId.hashCode();
         result = 31 * result + apiGatewayHost.hashCode();
         result = 31 * result + authorizeUri.hashCode();
         result = 31 * result + redirectUri.hashCode();
@@ -198,7 +212,7 @@ public final class LiAppCredentials {
     /**
      * Builder to create instances of {@link LiAppCredentials}.
      *
-     * @deprecated Use the default public constructor {@link #LiAppCredentials(String, String, String, String, String, String)} instead.
+     * @deprecated Use the default public constructor {@link #LiAppCredentials(String, String, String, String, String, String, String)} instead.
      */
     @Deprecated
     public static final class Builder {
@@ -320,7 +334,7 @@ public final class LiAppCredentials {
          */
         @NonNull
         public LiAppCredentials build() {
-            return new LiAppCredentials(clientName, clientKey, clientSecret, tenantId, communityUri, apiGatewayUri);
+            return new LiAppCredentials(clientName, clientKey, clientSecret, tenantId, communityUri, apiGatewayUri, "deviceId");
         }
     }
 }

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/auth/LiAppCredentials.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/auth/LiAppCredentials.java
@@ -148,6 +148,7 @@ public final class LiAppCredentials {
      * @return The client name
      * @deprecated Use {@link #getClientName()} instead.
      */
+    @Deprecated
     @NonNull
     public String getClientAppName() {
         return clientName;
@@ -157,6 +158,7 @@ public final class LiAppCredentials {
      * @return the API Gateways host address
      * @deprecated Use {@link #getApiGatewayHost()}
      */
+    @Deprecated
     @NonNull
     public String getApiProxyHost() {
         return getApiGatewayHost().toString();
@@ -198,6 +200,7 @@ public final class LiAppCredentials {
      *
      * @deprecated Use the default public constructor {@link #LiAppCredentials(String, String, String, String, String, String)} instead.
      */
+    @Deprecated
     public static final class Builder {
 
         private String clientName;
@@ -291,6 +294,7 @@ public final class LiAppCredentials {
          * @return this builder.
          * @deprecated Use {@link #getApiGatewayHost()} instead.
          */
+        @Deprecated
         public Builder setApiProxyHost(@NonNull String apiProxyHost) {
             this.apiGatewayUri = apiProxyHost;
             return this;
@@ -303,6 +307,7 @@ public final class LiAppCredentials {
          * @return this builder
          * @deprecated Use {@link #setClientName(String)}
          */
+        @Deprecated
         public Builder setClientAppName(@NonNull String clientAppName) {
             this.clientName = clientAppName;
             return this;

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/auth/LiAppCredentials.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/auth/LiAppCredentials.java
@@ -87,15 +87,15 @@ public final class LiAppCredentials {
     public LiAppCredentials(@NonNull String clientName, @NonNull String clientKey, @NonNull String clientSecret,
                             @NonNull String tenantId, @NonNull String communityURL, @NonNull String apiGatewayHost,
                             @NonNull String deviceId) {
-        this.clientName = LiCoreSDKUtils.checkNullOrNotEmpty(clientName, MessageConstants.wasEmpty("clientName"));
-        this.clientKey = LiCoreSDKUtils.checkNullOrNotEmpty(clientKey, MessageConstants.wasEmpty("clientKey"));
-        this.clientSecret = LiCoreSDKUtils.checkNullOrNotEmpty(clientSecret, MessageConstants.wasEmpty("clientSecret"));
-        this.tenantId = LiCoreSDKUtils.checkNullOrNotEmpty(tenantId, MessageConstants.wasEmpty("tenantId"));
+        this.clientName = LiCoreSDKUtils.checkNotNullAndNotEmpty(clientName, MessageConstants.wasEmpty("clientName"));
+        this.clientKey = LiCoreSDKUtils.checkNotNullAndNotEmpty(clientKey, MessageConstants.wasEmpty("clientKey"));
+        this.clientSecret = LiCoreSDKUtils.checkNotNullAndNotEmpty(clientSecret, MessageConstants.wasEmpty("clientSecret"));
+        this.tenantId = LiCoreSDKUtils.checkNotNullAndNotEmpty(tenantId, MessageConstants.wasEmpty("tenantId"));
 
-        this.communityUri = Uri.parse(LiCoreSDKUtils.checkNullOrNotEmpty(communityURL, MessageConstants.wasEmpty("communityURL")));
-        this.deviceId = LiCoreSDKUtils.checkNullOrNotEmpty(deviceId, MessageConstants.wasEmpty("deviceId"));
+        this.communityUri = Uri.parse(LiCoreSDKUtils.checkNotNullAndNotEmpty(communityURL, MessageConstants.wasEmpty("communityURL")));
+        this.deviceId = LiCoreSDKUtils.checkNotNullAndNotEmpty(deviceId, MessageConstants.wasEmpty("deviceId"));
 
-        this.apiGatewayHost = Uri.parse(LiCoreSDKUtils.checkNullOrNotEmpty(apiGatewayHost, MessageConstants.wasEmpty("apiGatewayHost")));
+        this.apiGatewayHost = Uri.parse(LiCoreSDKUtils.checkNotNullAndNotEmpty(apiGatewayHost, MessageConstants.wasEmpty("apiGatewayHost")));
 
         this.redirectUri = buildRedirectUri(communityUri);
         this.ssoAuthorizeUri = communityURL + SSO_AUTH_END_POINT;

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/auth/LiAuthServiceImpl.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/auth/LiAuthServiceImpl.java
@@ -86,6 +86,7 @@ public class LiAuthServiceImpl implements LiAuthService {
      * @param context Android context.
      * @deprecated use {@link #LiAuthServiceImpl(Context, LiSDKManager)} instead
      */
+    @Deprecated
     public LiAuthServiceImpl(@NonNull Context context) {
         this.context = LiCoreSDKUtils.checkNotNull(context);
         sdkManager = LiCoreSDKUtils.checkNotNull(LiSDKManager.getInstance(), "Li SDK Manager was null");

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/auth/LiAuthServiceImpl.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/auth/LiAuthServiceImpl.java
@@ -55,7 +55,8 @@ import static lithium.community.android.sdk.utils.LiCoreSDKConstants.LI_LOG_TAG;
 
 /**
  * Implementation class for LiAuthService. Starts login flow, performs authorization, fetches access and refresh tokens.
- * Created by shoureya.kant on 9/12/16.
+ *
+ * @author shoureya.kant
  */
 public class LiAuthServiceImpl implements LiAuthService {
 
@@ -391,7 +392,7 @@ public class LiAuthServiceImpl implements LiAuthService {
         request.setClientSecret(this.sdkManager.getCredentials().getClientSecret());
         request.setGrantType("refresh_token");
         request.setRefreshToken(this.sdkManager.getRefreshToken());
-        String uri = "https://" + this.sdkManager.getProxyHost() + "/auth/v1/refreshToken";
+        String uri = "https://" + this.sdkManager.getApiGatewayHost() + "/auth/v1/refreshToken";
         request.setUri(Uri.parse(uri));
 
         try {
@@ -455,7 +456,7 @@ public class LiAuthServiceImpl implements LiAuthService {
         request.setClientSecret(this.sdkManager.getCredentials().getClientSecret());
         request.setGrantType("refresh_token");
         request.setRefreshToken(this.sdkManager.getRefreshToken());
-        String uri = "https://" + this.sdkManager.getProxyHost() + "/auth/v1/refreshToken";
+        String uri = "https://" + this.sdkManager.getApiGatewayHost() + "/auth/v1/refreshToken";
         request.setUri(Uri.parse(uri));
 
         LiTokenResponse response = null;

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/auth/LiAuthorizationException.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/auth/LiAuthorizationException.java
@@ -247,7 +247,7 @@ public final class LiAuthorizationException extends Exception {
      * @throws JSONException if the JSON is malformed or missing required properties
      */
     public static LiAuthorizationException fromJson(@NonNull String jsonStr) throws JSONException {
-        LiCoreSDKUtils.checkNullOrNotEmpty(jsonStr, "jsonStr cannot be null or empty");
+        LiCoreSDKUtils.checkNotNullAndNotEmpty(jsonStr, "jsonStr cannot be null or empty");
         return fromJson(new JSONObject(jsonStr));
     }
 

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/exception/LiRestResponseException.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/exception/LiRestResponseException.java
@@ -65,7 +65,7 @@ public class LiRestResponseException extends Exception {
      * Reconstructs an {@link LiRestResponseException} from the JSON
      */
     public static LiRestResponseException fromJson(@NonNull String jsonStr, Gson gson) {
-        LiCoreSDKUtils.checkNullOrNotEmpty(jsonStr, "jsonStr cannot be null or empty");
+        LiCoreSDKUtils.checkNotNullAndNotEmpty(jsonStr, "jsonStr cannot be null or empty");
         JsonObject error = gson.fromJson(jsonStr, JsonObject.class);
         JsonObject data = error.get("data").getAsJsonObject();
         return new LiRestResponseException(error.get("http_code").getAsInt(),

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiAuthManager.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiAuthManager.java
@@ -30,7 +30,9 @@ import org.json.JSONException;
 import lithium.community.android.sdk.auth.LiAppCredentials;
 import lithium.community.android.sdk.auth.LiSSOAuthResponse;
 import lithium.community.android.sdk.auth.LiTokenResponse;
+import lithium.community.android.sdk.exception.LiInitializationException;
 import lithium.community.android.sdk.model.response.LiUser;
+import lithium.community.android.sdk.queryutil.LiDefaultQueryHelper;
 import lithium.community.android.sdk.utils.LiCoreSDKConstants;
 import lithium.community.android.sdk.utils.LiCoreSDKUtils;
 import lithium.community.android.sdk.utils.MessageConstants;
@@ -55,9 +57,11 @@ class LiAuthManager {
 
     private LiAuthState liAuthState;
 
-    LiAuthManager(@NonNull Context context, @NonNull LiAppCredentials credentials) {
+    LiAuthManager(@NonNull Context context, @NonNull LiAppCredentials credentials) throws LiInitializationException {
         this.liAuthState = restoreAuthState(LiCoreSDKUtils.checkNotNull(context, MessageConstants.wasNull("context")));
         this.credentials = LiCoreSDKUtils.checkNotNull(credentials, MessageConstants.wasNull("credentials"));
+        LiDefaultQueryHelper.initialize(context);
+        LiSecuredPrefManager.initialize(credentials.getClientSecret());
     }
 
     /**

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiAuthManager.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiAuthManager.java
@@ -80,6 +80,7 @@ class LiAuthManager {
      * @return the credentials.
      * @deprecated Use {@link #getCredentials()} instead.
      */
+    @Deprecated
     @NonNull
     public LiAppCredentials getLiAppCredentials() {
         return credentials;
@@ -91,6 +92,7 @@ class LiAuthManager {
      * @return the community URI.
      * @deprecated Use {@link #getCredentials()} and call {@link LiAppCredentials#getCommunityUri()} instead.
      */
+    @Deprecated
     public Uri getCommunityUrl() {
         return credentials.getCommunityUri();
     }

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiAuthManager.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiAuthManager.java
@@ -39,9 +39,6 @@ import lithium.community.android.sdk.utils.LiCoreSDKUtils;
 import lithium.community.android.sdk.utils.MessageConstants;
 
 import static lithium.community.android.sdk.utils.LiCoreSDKConstants.LI_AUTH_STATE;
-import static lithium.community.android.sdk.utils.LiCoreSDKConstants.LI_DEFAULT_SDK_SETTINGS;
-import static lithium.community.android.sdk.utils.LiCoreSDKConstants.LI_DEVICE_ID;
-import static lithium.community.android.sdk.utils.LiCoreSDKConstants.LI_RECEIVER_DEVICE_ID;
 
 /**
  * <p>
@@ -64,7 +61,7 @@ class LiAuthManager {
 
     LiAuthManager(@NonNull Context context, @NonNull LiAppCredentials credentials) throws LiInitializationException {
         this.credentials = LiCoreSDKUtils.checkNotNull(credentials, MessageConstants.wasNull("credentials"));
-        LiSecuredPrefManager.initialize(credentials.getClientSecret());
+        LiSecuredPrefManager.initialize(credentials.getClientSecret() + credentials.getDeviceId());
         LiDefaultQueryHelper.initialize(context);
         this.preferences = LiSecuredPrefManager.getInstance();
         this.state = restoreAuthState(LiCoreSDKUtils.checkNotNull(context, MessageConstants.wasNull("context")));
@@ -200,12 +197,10 @@ class LiAuthManager {
      *
      * @param context {@link Context}
      */
-    public void logout(Context context) {
-        removeFromSecuredPreferences(context, LI_DEFAULT_SDK_SETTINGS);
-        removeFromSecuredPreferences(context, LI_AUTH_STATE);
-        removeFromSecuredPreferences(context, LI_DEVICE_ID);
-        removeFromSecuredPreferences(context, LI_RECEIVER_DEVICE_ID);
-        removeFromSecuredPreferences(context, LiCoreSDKConstants.LI_SHARED_PREFERENCES_NAME);
+    public void logout(@NonNull Context context) {
+        LiCoreSDKUtils.checkNotNull(context, MessageConstants.wasNull("context"));
+
+        preferences.clear(context);
 
         // For clearing cookies, if the android OS is Lollipop (5.0) and above use new
         // way of using CookieManager else use the deprecate methods for older versions.

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiAuthState.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiAuthState.java
@@ -37,7 +37,7 @@ import lithium.community.android.sdk.utils.LiSystemClock;
 
 import static lithium.community.android.sdk.utils.LiCoreSDKUtils.checkArgument;
 import static lithium.community.android.sdk.utils.LiCoreSDKUtils.checkNotNull;
-import static lithium.community.android.sdk.utils.LiCoreSDKUtils.checkNullOrNotEmpty;
+import static lithium.community.android.sdk.utils.LiCoreSDKUtils.checkNotNullAndNotEmpty;
 
 /**
  * This class holds all the Authorization related responses and the Tokens.
@@ -129,7 +129,7 @@ class LiAuthState {
      * @throws JSONException if the provided JSON does not match the expected structure.
      */
     static LiAuthState deserialize(@NonNull String string) throws JSONException {
-        checkNullOrNotEmpty(string, "jsonStr cannot be null or empty");
+        checkNotNullAndNotEmpty(string, "jsonStr cannot be null or empty");
         return deserialize(new JSONObject(string));
     }
 

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiAuthState.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiAuthState.java
@@ -45,12 +45,9 @@ import static lithium.community.android.sdk.utils.LiCoreSDKUtils.checkNullOrNotE
  */
 class LiAuthState {
 
-    private static final String LOG_TAG = "LiSDKAuth";
-
     /**
-     * Tokens which have less time than this value left before expiry will be considered to be
-     * expired for the purposes of calls to
-     * performActionWithFreshTokens}.
+     * Tokens which have less time than this value left before expiry will be
+     * considered to be expired for the purposes of calls to performActionWithFreshTokens.
      */
     private static final int EXPIRY_TIME_TOLERANCE_MS = 60000;
     private static final String KEY_REFRESH_TOKEN = "refreshToken";
@@ -94,19 +91,18 @@ class LiAuthState {
 
     /**
      * Reads an authorization state instance from a JSON string representation produced by
-     * {@link #jsonSerialize()}.
+     * {@link #serialize()}.
      *
      * @throws JSONException if the provided JSON does not match the expected structure.
      */
-    private static LiAuthState jsonDeserialize(@NonNull JSONObject json) throws JSONException {
+    private static LiAuthState deserialize(@NonNull JSONObject json) throws JSONException {
         checkNotNull(json, "json cannot be null");
         Gson gson = new Gson();
         LiAuthState state = new LiAuthState();
         state.mRefreshToken = LiCoreSDKUtils.getStringIfDefined(json, KEY_REFRESH_TOKEN);
         state.mScope = LiCoreSDKUtils.getStringIfDefined(json, KEY_SCOPE);
         if (json.has(KEY_AUTHORIZATION_EXCEPTION)) {
-            state.mLiAuthorizationException = LiAuthorizationException.fromJson(
-                    json.getJSONObject(KEY_AUTHORIZATION_EXCEPTION));
+            state.mLiAuthorizationException = LiAuthorizationException.fromJson(json.getJSONObject(KEY_AUTHORIZATION_EXCEPTION));
         }
 
         if (json.has(KEY_LOGGED_IN_USER)) {
@@ -127,14 +123,14 @@ class LiAuthState {
 
     /**
      * Reads an authorization state instance from a JSON string representation produced by
-     * {@link #jsonSerializeString()}. This method is just a convenience wrapper for
-     * {@link #jsonDeserialize(JSONObject)}, converting the JSON string to its JSON object form.
+     * {@link #toJsonString()}. This method is just a convenience wrapper for
+     * {@link #deserialize(JSONObject)}, converting the JSON string to its JSON object form.
      *
      * @throws JSONException if the provided JSON does not match the expected structure.
      */
-    static LiAuthState jsonDeserialize(@NonNull String jsonStr) throws JSONException {
-        checkNullOrNotEmpty(jsonStr, "jsonStr cannot be null or empty");
-        return jsonDeserialize(new JSONObject(jsonStr));
+    static LiAuthState deserialize(@NonNull String string) throws JSONException {
+        checkNullOrNotEmpty(string, "jsonStr cannot be null or empty");
+        return deserialize(new JSONObject(string));
     }
 
     /**
@@ -172,29 +168,17 @@ class LiAuthState {
 
     @Nullable
     public String getProxyHost() {
-        if (isSSOLogin) {
-            if (mLastLiSSOAuthResponse != null) {
-                return mLastLiSSOAuthResponse.getApiProxyHost();
-            }
-        }
-
-        return null;
+        return isSSOLogin && mLastLiSSOAuthResponse != null ? mLastLiSSOAuthResponse.getApiProxyHost() : null;
     }
 
     /**
      * provides tenant id fetched during authorization.
      *
-     * @return
+     * @return the tenant id
      */
     @Nullable
     public String getTenantId() {
-        if (isSSOLogin) {
-            if (mLastLiSSOAuthResponse != null) {
-                return mLastLiSSOAuthResponse.getTenantId();
-            }
-        }
-
-        return null;
+        return isSSOLogin && mLastLiSSOAuthResponse != null ? mLastLiSSOAuthResponse.getTenantId() : null;
     }
 
     /**
@@ -202,14 +186,7 @@ class LiAuthState {
      */
     @Nullable
     String getAccessToken() {
-        if (isSSOLogin) {
-            if (mLastLiTokenResponse != null) {
-                return mLastLiTokenResponse.getAccessToken();
-            }
-            return null;
-        }
-
-        return null;
+        return isSSOLogin && mLastLiTokenResponse != null ? mLastLiTokenResponse.getAccessToken() : null;
     }
 
     /**
@@ -218,14 +195,7 @@ class LiAuthState {
      */
     @Nullable
     Long getAccessTokenExpirationTime() {
-        if (isSSOLogin) {
-            if (mLastLiTokenResponse != null) {
-                return mLastLiTokenResponse.getExpiresAt();
-            }
-            return null;
-
-        }
-        return -1L;
+        return isSSOLogin && mLastLiTokenResponse != null ? mLastLiTokenResponse.getExpiresAt() : -1L;
     }
 
     /**
@@ -233,10 +203,7 @@ class LiAuthState {
      * from which at least either an access token or an ID token have been retrieved.
      */
     boolean isAuthorized() {
-        if (isSSOLogin) {
-            return getAccessToken() != null;
-        }
-        return false;
+        return isSSOLogin && getAccessToken() != null;
     }
 
     /**
@@ -267,8 +234,7 @@ class LiAuthState {
                 return getAccessToken() == null;
             }
 
-            return getAccessTokenExpirationTime()
-                    <= liClock.getCurrentTimeMillis() + EXPIRY_TIME_TOLERANCE_MS;
+            return getAccessTokenExpirationTime() <= liClock.getCurrentTimeMillis() + EXPIRY_TIME_TOLERANCE_MS;
 
         } else {
             if (mNeedsTokenRefreshOverride) {
@@ -281,16 +247,14 @@ class LiAuthState {
                 return getAccessToken() == null;
             }
 
-            return getAccessTokenExpirationTime()
-                    <= liClock.getCurrentTimeMillis() + EXPIRY_TIME_TOLERANCE_MS;
+            return getAccessTokenExpirationTime() <= liClock.getCurrentTimeMillis() + EXPIRY_TIME_TOLERANCE_MS;
         }
     }
 
     /**
      * Updates the authorization state based on a new authorization response.
      */
-    void update(
-            @Nullable LiSSOAuthResponse authResponse) {
+    void update(@Nullable LiSSOAuthResponse authResponse) {
         checkArgument(authResponse != null, "exactly one of authResponse or authException should be non-null");
 
         // the last token response and refresh token are now stale, as they are associated with
@@ -299,7 +263,6 @@ class LiAuthState {
         mLiAuthorizationException = null;
 
         // if the response's mScope is null, it means that it equals that of the request
-
         mScope = null;
         mLastLiSSOAuthResponse = authResponse;
         mProxyHost = authResponse.getApiProxyHost();
@@ -309,21 +272,18 @@ class LiAuthState {
     /**
      * Updates the authorization state based on a new token response.
      */
-    void update(
-            @Nullable LiTokenResponse liTokenResponse) {
+    void update(@Nullable LiTokenResponse liTokenResponse) {
         checkArgument(liTokenResponse != null, "no tokenResponse ");
-
         mLastLiTokenResponse = liTokenResponse;
         mScope = null;
         mRefreshToken = liTokenResponse.getRefreshToken();
-
     }
 
     /**
      * Produces a JSON representation of the authorization state for persistent storage or local
      * transmission (e.g. between activities).
      */
-    JSONObject jsonSerialize() {
+    JSONObject serialize() {
         JSONObject json = new JSONObject();
         LiCoreSDKUtils.putIfNotNull(json, KEY_REFRESH_TOKEN, mRefreshToken);
         LiCoreSDKUtils.putIfNotNull(json, KEY_SCOPE, mScope);
@@ -333,23 +293,13 @@ class LiAuthState {
         }
 
         if (mLastLiSSOAuthResponse != null) {
-            LiCoreSDKUtils.put(
-                    json,
-                    KEY_LAST_SSO_AUTHORIZATION_RESPONSE,
-                    mLastLiSSOAuthResponse.getJsonString());
+            LiCoreSDKUtils.put(json, KEY_LAST_SSO_AUTHORIZATION_RESPONSE, mLastLiSSOAuthResponse.getJsonString());
         }
         if (mLastLiTokenResponse != null) {
-            LiCoreSDKUtils.put(
-                    json,
-                    KEY_LI_LAST_TOKEN_RESPONSE,
-                    mLastLiTokenResponse.getJsonString());
+            LiCoreSDKUtils.put(json, KEY_LI_LAST_TOKEN_RESPONSE, mLastLiTokenResponse.getJsonString());
         }
-
         if (user != null) {
-            LiCoreSDKUtils.put(
-                    json,
-                    KEY_LOGGED_IN_USER,
-                    user.jsonSerialize());
+            LiCoreSDKUtils.put(json, KEY_LOGGED_IN_USER, user.jsonSerialize());
         }
 
         return json;
@@ -358,10 +308,10 @@ class LiAuthState {
     /**
      * Produces a JSON string representation of the authorization state for persistent storage or
      * local transmission (e.g. between activities). This method is just a convenience wrapper
-     * for {@link #jsonSerialize()}, converting the JSON object to its string form.
+     * for {@link #serialize()}, converting the JSON object to its string form.
      */
-    String jsonSerializeString() {
-        return jsonSerialize().toString();
+    String toJsonString() {
+        return serialize().toString();
     }
 
     /**

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiClientManager.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiClientManager.java
@@ -84,87 +84,76 @@ import static lithium.community.android.sdk.utils.LiQueryConstant.LI_USER_DETAIL
  */
 public class LiClientManager {
 
-    public static LiRestv2Client getRestClient() throws LiRestResponseException {
+    public static LiRestv2Client getRestClient() {
         return LiRestv2Client.getInstance();
     }
 
     /**
      * Fetches a list of all the articles for the user in context ordered by post time or kudos count. Create
-     * parameters with {@LiClientRequestParams.LiMessagesClientRequestParams}.
+     * parameters with {@link LiClientRequestParams.LiMessagesClientRequestParams}.
      *
-     * @param liClientRequestParams {@LiClientRequestParams.LiMessagesClientRequestParams} the Android context
-     *                              (required)
+     * @param params {@link LiClientRequestParams.LiMessagesClientRequestParams} the Android context (required)
      * @return LiMessage {@link LiMessage}
      * @throws LiRestResponseException {@link LiRestResponseException}
      */
-    public static LiClient getMessagesClient(
-            LiClientRequestParams liClientRequestParams) throws LiRestResponseException {
-        liClientRequestParams.validate(Client.LI_MESSAGES_CLIENT);
+    public static LiClient getMessagesClient(LiClientRequestParams params) throws LiRestResponseException {
+        params.validate(Client.LI_MESSAGES_CLIENT);
         LiQueryValueReplacer liQueryValueReplacer = new LiQueryValueReplacer();
         liQueryValueReplacer.replaceAll("##", "0");
-        return new LiBaseGetClient(liClientRequestParams.getContext(), LiQueryConstant.LI_MESSAGE_LIST_BASE_LIQL,
-                LiQueryConstant.LI_ARTICLES_CLIENT_TYPE, LiQueryConstant.LI_ARTICLES_QUERYSETTINGS_TYPE,
-                LiMessage.class).setReplacer(liQueryValueReplacer);
+
+        return new LiBaseGetClient(params.getContext(), LiQueryConstant.LI_MESSAGE_LIST_BASE_LIQL,
+                LiQueryConstant.LI_ARTICLES_CLIENT_TYPE, LiQueryConstant.LI_ARTICLES_QUERYSETTINGS_TYPE, LiMessage.class).setReplacer(liQueryValueReplacer);
     }
 
     /**
      * Fetches all articles on the specified board, authored by the user in context. Create parameters with
-     * {@LiClientRequestParams.LiMessagesByBoardIdClientRequestParams}.
+     * {@link LiClientRequestParams.LiMessagesByBoardIdClientRequestParams}.
      *
-     * @param liClientRequestParams {@LiClientRequestParams.LiMessagesByBoardIdClientRequestParams} the Android
-     *                              context (required)
-     * @param liClientRequestParams the ID of the board from which to fetch the messages (required)
+     * @param params {@link LiClientRequestParams.LiMessagesByBoardIdClientRequestParams}
      * @return LiMessage {@link LiMessage}
      * @throws LiRestResponseException {@link LiRestResponseException}
      */
-    public static LiClient getMessagesByBoardIdClient(
-            LiClientRequestParams liClientRequestParams) throws LiRestResponseException {
-        liClientRequestParams.validate(Client.LI_MESSAGES_BY_BOARD_ID_CLIENT);
-        String boardId
-                = ((LiClientRequestParams.LiMessagesByBoardIdClientRequestParams) liClientRequestParams).getBoardId();
+    public static LiClient getMessagesByBoardIdClient(LiClientRequestParams params) throws LiRestResponseException {
+        params.validate(Client.LI_MESSAGES_BY_BOARD_ID_CLIENT);
+        String boardId = ((LiClientRequestParams.LiMessagesByBoardIdClientRequestParams) params).getBoardId();
         LiQueryValueReplacer liQueryValueReplacer = new LiQueryValueReplacer();
         liQueryValueReplacer.replaceAll("##", boardId).replaceAll("&&", "0");
-        return new LiBaseGetClient(liClientRequestParams.getContext(), LiQueryConstant.LI_MESSAGE_LIST_BASE_LIQL,
-                LiQueryConstant.LI_ARTICLES_BROWSE_CLIENT_TYPE, LiQueryConstant.LI_ARTICLES_BROWSE_QUERYSETTINGS_TYPE,
-                LiMessage.class).setReplacer(liQueryValueReplacer);
+
+        return new LiBaseGetClient(params.getContext(), LiQueryConstant.LI_MESSAGE_LIST_BASE_LIQL,
+                LiQueryConstant.LI_ARTICLES_BROWSE_CLIENT_TYPE, LiQueryConstant.LI_ARTICLES_BROWSE_QUERYSETTINGS_TYPE, LiMessage.class)
+                .setReplacer(liQueryValueReplacer);
     }
 
     /**
-     * Fetches all the SDK settings from the Community app. Create parameters with {@LiClientRequestParams
-     * .LiSdkSettingsClientRequestParams}.
+     * Fetches all the SDK settings from the Community app. Create parameters with {@link LiClientRequestParams.LiSdkSettingsClientRequestParams}.
      *
-     * @param liClientRequestParams {@LiClientRequestParams.LiSdkSettingsClientRequestParams} the Android context
-     *                              (required)
-     * @param liClientRequestParams the client ID (required)
+     * @param params {@link LiClientRequestParams.LiSdkSettingsClientRequestParams}
      * @return LiClient {@link LiClient}
      * @throws LiRestResponseException {@link LiRestResponseException}
      */
-    public static LiClient getSdkSettingsClient(
-            LiClientRequestParams liClientRequestParams) throws LiRestResponseException {
-        liClientRequestParams.validate(Client.LI_SDK_SETTINGS_CLIENT);
-        String clientId
-                = ((LiClientRequestParams.LiSdkSettingsClientRequestParams) liClientRequestParams).getClientId();
+    public static LiClient getSdkSettingsClient(LiClientRequestParams params) throws LiRestResponseException {
+        params.validate(Client.LI_SDK_SETTINGS_CLIENT);
+        String clientId = ((LiClientRequestParams.LiSdkSettingsClientRequestParams) params).getClientId();
         LiQueryValueReplacer liQueryValueReplacer = new LiQueryValueReplacer();
         liQueryValueReplacer.replaceAll("##", clientId);
-        return new LiBaseGetClient(liClientRequestParams.getContext(), LiQueryConstant.LI_SDK_SETTINGS_CLIENT_BASE_LIQL,
-                LiQueryConstant.LI_SDK_SETTINGS_CLIENT_TYPE, LiQueryConstant.LI_SDK_SETTINGS_QUERYSETTINGS_TYPE,
-                LiAppSdkSettings.class).setReplacer(liQueryValueReplacer);
+
+        return new LiBaseGetClient(params.getContext(), LiQueryConstant.LI_SDK_SETTINGS_CLIENT_BASE_LIQL,
+                LiQueryConstant.LI_SDK_SETTINGS_CLIENT_TYPE, LiQueryConstant.LI_SDK_SETTINGS_QUERYSETTINGS_TYPE, LiAppSdkSettings.class)
+                .setReplacer(liQueryValueReplacer);
     }
 
     /**
      * Fetches a list of all Community subscriptions for the user in context. Create parameters with
-     * {@LiClientRequestParams.LiUserSubscriptionsClientRequestParams}.
+     * {@link LiClientRequestParams.LiUserSubscriptionsClientRequestParams}.
      *
-     * @param liClientRequestParams {@LiClientRequestParams.LiUserSubscriptionsClientRequestParams} the Android
-     *                              context (required)
+     * @param params {@link LiClientRequestParams.LiUserSubscriptionsClientRequestParams} (required)
      * @return LiSubscription {@link LiSubscriptions}
      * @throws LiRestResponseException {@link LiRestResponseException}
      */
-    public static LiClient getUserSubscriptionsClient(
-            LiClientRequestParams liClientRequestParams) throws LiRestResponseException {
-        liClientRequestParams.validate(Client.LI_USER_SUBSCRIPTIONS_CLIENT);
-        return new LiBaseGetClient(liClientRequestParams.getContext(),
-                LiQueryConstant.LI_SUBSCRIPTIONS_CLIENT_BASE_LIQL, LI_SUBSCRIPTIONS_CLIENT_TYPE,
+    public static LiClient getUserSubscriptionsClient(LiClientRequestParams params) throws LiRestResponseException {
+        params.validate(Client.LI_USER_SUBSCRIPTIONS_CLIENT);
+
+        return new LiBaseGetClient(params.getContext(), LiQueryConstant.LI_SUBSCRIPTIONS_CLIENT_BASE_LIQL, LI_SUBSCRIPTIONS_CLIENT_TYPE,
                 LiQueryConstant.LI_SUBSCRIPTTION_QUERYSETTINGS_TYPE, LiSubscriptions.class);
     }
 
@@ -172,214 +161,173 @@ public class LiClientManager {
      * Fetches a list of boards for a given category, along with board and category details. Create parameters with
      * {@link LiClientRequestParams.LiCategoryBoardsClientRequestParams}.
      *
-     * @param liClientRequestParams {@link LiClientRequestParams.LiCategoryBoardsClientRequestParams} the Android
-     *                              context (required)
-     * @param liClientRequestParams the category ID (required)
+     * @param params {@link LiClientRequestParams.LiCategoryBoardsClientRequestParams}
      * @return LiBrowse {@link LiBrowse}
      * @throws LiRestResponseException {@link LiRestResponseException}
      */
-    public static LiClient getCategoryBoardsClient(
-            LiClientRequestParams liClientRequestParams) throws LiRestResponseException {
-        liClientRequestParams.validate(Client.LI_CATEGORY_BOARDS_CLIENT);
-        String categoryId
-                = ((LiClientRequestParams.LiCategoryBoardsClientRequestParams) liClientRequestParams).getCategoryId();
+    public static LiClient getCategoryBoardsClient(LiClientRequestParams params) throws LiRestResponseException {
+        params.validate(Client.LI_CATEGORY_BOARDS_CLIENT);
+        String categoryId = ((LiClientRequestParams.LiCategoryBoardsClientRequestParams) params).getCategoryId();
         LiQueryValueReplacer liQueryValueReplacer = new LiQueryValueReplacer();
         liQueryValueReplacer.replaceAll("##", categoryId);
-        return new LiBaseGetClient(liClientRequestParams.getContext(), LiQueryConstant.LI_BROWSE_CLIENT_BASE_LIQL,
-                LiQueryConstant.LI_BROWSE_CLIENT_TYPE, LiQueryConstant.LI_BROWSE_QUERYSETTINGS_TYPE,
-                LiBrowse.class).setReplacer(liQueryValueReplacer);
+
+        return new LiBaseGetClient(params.getContext(), LiQueryConstant.LI_BROWSE_CLIENT_BASE_LIQL, LiQueryConstant.LI_BROWSE_CLIENT_TYPE,
+                LiQueryConstant.LI_BROWSE_QUERYSETTINGS_TYPE, LiBrowse.class).setReplacer(liQueryValueReplacer);
     }
 
     /**
      * Fetches boards at a specific depth in the Community Structure hierarchy. 0 is the highest level in the
      * structure. Create parameters with {@link LiClientRequestParams.LiBoardsByDepthClientRequestParams}.
      *
-     * @param liClientRequestParams {@link LiClientRequestParams.LiBoardsByDepthClientRequestParams} the Android
-     *                              context (required)
-     * @param liClientRequestParams the depth of boards to include in the query (required)
+     * @param params {@link LiClientRequestParams.LiBoardsByDepthClientRequestParams}.
      * @return LiBrowse {@link LiBrowse}
      * @throws LiRestResponseException {@link LiRestResponseException}
      */
-    public static LiClient getBoardsByDepthClient(
-            LiClientRequestParams liClientRequestParams) throws LiRestResponseException {
-        liClientRequestParams.validate(Client.LI_BOARDS_BY_DEPTH_CLIENT);
-        int depth = ((LiClientRequestParams.LiBoardsByDepthClientRequestParams) liClientRequestParams).getDepth();
+    public static LiClient getBoardsByDepthClient(LiClientRequestParams params) throws LiRestResponseException {
+        params.validate(Client.LI_BOARDS_BY_DEPTH_CLIENT);
+        int depth = ((LiClientRequestParams.LiBoardsByDepthClientRequestParams) params).getDepth();
         LiQueryValueReplacer liQueryValueReplacer = new LiQueryValueReplacer();
         liQueryValueReplacer.replaceAll("##", String.valueOf(depth));
-        return new LiBaseGetClient(liClientRequestParams.getContext(), LiQueryConstant.LI_BROWSE_CLIENT_BASE_LIQL,
-                LiQueryConstant.LI_BROWSE_CLIENT_TYPE, LiQueryConstant.LI_BROWSE_BY_DEPTH_QUERYSETTINGS_TYPE,
-                LiBrowse.class).setReplacer(liQueryValueReplacer);
+
+        return new LiBaseGetClient(params.getContext(), LiQueryConstant.LI_BROWSE_CLIENT_BASE_LIQL, LiQueryConstant.LI_BROWSE_CLIENT_TYPE,
+                LiQueryConstant.LI_BROWSE_BY_DEPTH_QUERYSETTINGS_TYPE, LiBrowse.class).setReplacer(liQueryValueReplacer);
     }
 
     /**
      * Fetches details of child messages of the specified message. Child messages include replies comments, as well
      * as nested replies or comments. Create parameters with {@link LiClientRequestParams.LiRepliesClientRequestParams}.
      *
-     * @param liClientRequestParams {@link LiClientRequestParams.LiRepliesClientRequestParams} the Android context
-     *                              (required)
-     * @param liClientRequestParams the ID of the parent message (required)
+     * @param params {@link LiClientRequestParams.LiRepliesClientRequestParams}.
      * @return LiMessage {@link LiMessage}
      * @throws LiRestResponseException {@link LiRestResponseException}
      */
     @NonNull
-    public static LiClient getRepliesClient(
-            LiClientRequestParams liClientRequestParams) throws LiRestResponseException {
-        liClientRequestParams.validate(Client.LI_REPLIES_CLIENT);
-        Long parentId = ((LiClientRequestParams.LiRepliesClientRequestParams) liClientRequestParams).getParentId();
+    public static LiClient getRepliesClient(LiClientRequestParams params) throws LiRestResponseException {
+        params.validate(Client.LI_REPLIES_CLIENT);
+        Long parentId = ((LiClientRequestParams.LiRepliesClientRequestParams) params).getParentId();
         LiQueryValueReplacer liQueryValueReplacer = new LiQueryValueReplacer();
         liQueryValueReplacer.replaceAll("##", String.valueOf(parentId));
-        return new LiBaseGetClient(liClientRequestParams.getContext(),
-                LiQueryConstant.LI_MESSAGE_CONVERSATION_BASE_LIQL, LiQueryConstant.LI_MESSAGE_CHILDREN_CLIENT_TYPE,
-                LiQueryConstant.LI_MESSAGE_CHILDREN_QUERYSETTINGS_TYPE, LiMessage.class).setReplacer(
-                liQueryValueReplacer);
+
+        return new LiBaseGetClient(params.getContext(), LiQueryConstant.LI_MESSAGE_CONVERSATION_BASE_LIQL,
+                LiQueryConstant.LI_MESSAGE_CHILDREN_CLIENT_TYPE, LiQueryConstant.LI_MESSAGE_CHILDREN_QUERYSETTINGS_TYPE, LiMessage.class)
+                .setReplacer(liQueryValueReplacer);
     }
 
     /**
-     * Performs a keyword search in the community. Create parameters with
-     * {@link LiClientRequestParams.LiSearchClientRequestParams}.
+     * Performs a keyword search in the community. Create parameters with {@link LiClientRequestParams.LiSearchClientRequestParams}.
      *
-     * @param liClientRequestParams {@link LiClientRequestParams.LiSearchClientRequestParams} the Android context
-     *                              (required)
-     * @param liClientRequestParams the text string to search, passed as 'query'. The 'query' parameter is compared
-     *                              with the body and subject of the message. (required)
+     * @param params the text string to search, passed as 'query'. The 'query' parameter is compared
+     *               with the body and subject of the message. (required)
      * @return LiMessage {@link LiMessage}
      * @throws LiRestResponseException {@link LiRestResponseException}
      */
-    public static LiClient getSearchClient(LiClientRequestParams liClientRequestParams) throws LiRestResponseException {
-        liClientRequestParams.validate(Client.LI_SEARCH_CLIENT);
-        String query = ((LiClientRequestParams.LiSearchClientRequestParams) liClientRequestParams).getQuery();
+    public static LiClient getSearchClient(LiClientRequestParams params) throws LiRestResponseException {
+        params.validate(Client.LI_SEARCH_CLIENT);
+        String query = ((LiClientRequestParams.LiSearchClientRequestParams) params).getQuery();
         LiQueryValueReplacer liQueryValueReplacer = new LiQueryValueReplacer();
         liQueryValueReplacer.replaceAll("##", query);
-        return new LiBaseGetClient(liClientRequestParams.getContext(),
-                String.format(LiQueryConstant.LI_MESSAGE_LIST_BASE_LIQL, query), LiQueryConstant.LI_SEARCH_CLIENT_TYPE,
-                LiQueryConstant.LI_SEARCH_QUERYSETTINGS_TYPE, LiMessage.class).setReplacer(liQueryValueReplacer);
+
+        return new LiBaseGetClient(params.getContext(), String.format(LiQueryConstant.LI_MESSAGE_LIST_BASE_LIQL, query),
+                LiQueryConstant.LI_SEARCH_CLIENT_TYPE, LiQueryConstant.LI_SEARCH_QUERYSETTINGS_TYPE, LiMessage.class).setReplacer(liQueryValueReplacer);
     }
 
     /**
      * Fetches messages posted by a specified author up to a specified depth in the Community Structure hierarchy.
      * Crate parameters with {@link LiClientRequestParams.LiUserMessagesClientRequestParams}.
      *
-     * @param liClientRequestParams {@link LiClientRequestParams.LiUserMessagesClientRequestParams}  the Android
-     *                              context (required)
-     * @param liClientRequestParams the ID of the author (required)
-     * @param liClientRequestParams the depth of the message, where the a topic message = 0, the first reply = 1, and
-     *                              so on (required)
+     * @param params the depth of the message, where the a topic message = 0, the first reply = 1, and so on (required).
      * @return LiClient {@link LiClient}
      * @throws LiRestResponseException {@link LiRestResponseException}
      */
-    public static LiClient getUserMessagesClient(
-            LiClientRequestParams liClientRequestParams) throws LiRestResponseException {
-        liClientRequestParams.validate(Client.LI_USER_MESSAGES_CLIENT);
-        Long authorId = ((LiClientRequestParams.LiUserMessagesClientRequestParams) liClientRequestParams).getAuthorId();
-        String depth = ((LiClientRequestParams.LiUserMessagesClientRequestParams) liClientRequestParams).getDepth();
+    public static LiClient getUserMessagesClient(LiClientRequestParams params) throws LiRestResponseException {
+        params.validate(Client.LI_USER_MESSAGES_CLIENT);
+        Long authorId = ((LiClientRequestParams.LiUserMessagesClientRequestParams) params).getAuthorId();
+        String depth = ((LiClientRequestParams.LiUserMessagesClientRequestParams) params).getDepth();
         LiQueryValueReplacer liQueryValueReplacer = new LiQueryValueReplacer();
         liQueryValueReplacer.replaceAll("##", String.valueOf(authorId)).replaceAll("&&", depth);
-        return new LiBaseGetClient(liClientRequestParams.getContext(), LiQueryConstant.LI_MESSAGE_LIST_BASE_LIQL,
-                LiQueryConstant.LI_QUESTIONS_CLIENT_TYPE, LiQueryConstant.LI_QUESTIONS_QUERYSETTINGS_TYPE,
-                LiMessage.class).setReplacer(liQueryValueReplacer);
+
+        return new LiBaseGetClient(params.getContext(), LiQueryConstant.LI_MESSAGE_LIST_BASE_LIQL, LiQueryConstant.LI_QUESTIONS_CLIENT_TYPE,
+                LiQueryConstant.LI_QUESTIONS_QUERYSETTINGS_TYPE, LiMessage.class).setReplacer(liQueryValueReplacer);
     }
 
     /**
      * Fetches category details available to the user in context. This method respects the Hide from Lists and Menus
-     * setting in Community Admin.
-     * Create parameters with {@link LiClientRequestParams.LiCategoryClientRequestParams}.
+     * setting in Community Admin. Create parameters with {@link LiClientRequestParams.LiCategoryClientRequestParams}.
      *
-     * @param liClientRequestParams {@link LiClientRequestParams.LiCategoryClientRequestParams} the Android context
-     *                              (required)
+     * @param params {@link LiClientRequestParams.LiCategoryClientRequestParams}.
      * @return LiBrowse {@link LiBrowse}
      * @throws LiRestResponseException {@link LiRestResponseException}
      */
-    public static LiClient getCategoryClient(
-            LiClientRequestParams liClientRequestParams) throws LiRestResponseException {
-        liClientRequestParams.validate(Client.LI_CATEGORY_CLIENT);
-        return new LiBaseGetClient(liClientRequestParams.getContext(), LiQueryConstant.LI_CATEGORY_CLIENT_BASE_LIQL,
-                LiQueryConstant.LI_CATEGORY_CLIENT_TYPE, LiQueryConstant.LI_CATEGORY_QUERYSETTINGS_TYPE,
-                LiBrowse.class);
+    public static LiClient getCategoryClient(LiClientRequestParams params) throws LiRestResponseException {
+        params.validate(Client.LI_CATEGORY_CLIENT);
+        return new LiBaseGetClient(params.getContext(), LiQueryConstant.LI_CATEGORY_CLIENT_BASE_LIQL, LiQueryConstant.LI_CATEGORY_CLIENT_TYPE,
+                LiQueryConstant.LI_CATEGORY_QUERYSETTINGS_TYPE, LiBrowse.class);
     }
 
     /**
-     * Fetches all details about the specified user. Create parameters with
-     * {@link LiClientRequestParams.LiUserDetailsClientRequestParams}.
+     * Fetches all details about the specified user. Create parameters with {@link LiClientRequestParams.LiUserDetailsClientRequestParams}.
      *
-     * @param liClientRequestParams {@link LiClientRequestParams.LiUserDetailsClientRequestParams} the Android
-     *                              context (required)
-     * @param liClientRequestParams the ID of the user (required)
+     * @param params {@link LiClientRequestParams.LiUserDetailsClientRequestParams}.
      * @return LUser {@link LiUser}
      * @throws LiRestResponseException LiClient {@link LiRestResponseException}
      */
-    public static LiClient getUserDetailsClient(
-            LiClientRequestParams liClientRequestParams) throws LiRestResponseException {
-        liClientRequestParams.validate(Client.LI_USER_DETAILS_CLIENT);
-        String userId = ((LiClientRequestParams.LiUserDetailsClientRequestParams) liClientRequestParams).getUserId();
+    public static LiClient getUserDetailsClient(LiClientRequestParams params) throws LiRestResponseException {
+        params.validate(Client.LI_USER_DETAILS_CLIENT);
+        String userId = ((LiClientRequestParams.LiUserDetailsClientRequestParams) params).getUserId();
         LiQueryValueReplacer liQueryValueReplacer = new LiQueryValueReplacer();
         liQueryValueReplacer.replaceAll("##", userId);
-        return new LiBaseGetClient(liClientRequestParams.getContext(), LiQueryConstant.LI_USER_DETAILS_CLIENT_BASE_LIQL,
-                LI_USER_DETAILS_CLIENT_TYPE, LiQueryConstant.LI_USER_DETAILS_QUERYSETTINGS_TYPE,
-                LiUser.class).setReplacer(liQueryValueReplacer);
+        return new LiBaseGetClient(params.getContext(), LiQueryConstant.LI_USER_DETAILS_CLIENT_BASE_LIQL, LI_USER_DETAILS_CLIENT_TYPE,
+                LiQueryConstant.LI_USER_DETAILS_QUERYSETTINGS_TYPE, LiUser.class).setReplacer(liQueryValueReplacer);
     }
 
     /**
-     * Fetches details of the specified message. Create parameters with
-     * {@link LiClientRequestParams.LiMessageClientRequestParams}.
+     * Fetches details of the specified message. Create parameters with {@link LiClientRequestParams.LiMessageClientRequestParams}.
      *
-     * @param liClientRequestParams {@link LiClientRequestParams.LiMessageClientRequestParams} the Android context
-     *                              (required)
-     * @param liClientRequestParams the ID of the message (required)
+     * @param params {@link LiClientRequestParams.LiMessageClientRequestParams}.
      * @return LiMessage {@link LiMessage}
      * @throws LiRestResponseException {@link LiRestResponseException}
      */
-    public static LiClient getMessageClient(
-            LiClientRequestParams liClientRequestParams) throws LiRestResponseException {
-        liClientRequestParams.validate(Client.LI_MESSAGE_CLIENT);
-        Long messageId = ((LiClientRequestParams.LiMessageClientRequestParams) liClientRequestParams).getMessageId();
+    public static LiClient getMessageClient(LiClientRequestParams params) throws LiRestResponseException {
+        params.validate(Client.LI_MESSAGE_CLIENT);
+        Long messageId = ((LiClientRequestParams.LiMessageClientRequestParams) params).getMessageId();
         LiQueryValueReplacer liQueryValueReplacer = new LiQueryValueReplacer();
         liQueryValueReplacer.replaceAll("##", String.valueOf(messageId));
-        return new LiBaseGetClient(liClientRequestParams.getContext(),
-                LiQueryConstant.LI_MESSAGE_CONVERSATION_BASE_LIQL, LiQueryConstant.LI_MESSAGE_CLIENT_TYPE,
-                LiQueryConstant.LI_MESSAGE_QUERYSETTINGS_TYPE, LiMessage.class).setReplacer(liQueryValueReplacer);
+
+        return new LiBaseGetClient(params.getContext(), LiQueryConstant.LI_MESSAGE_CONVERSATION_BASE_LIQL,
+                LiQueryConstant.LI_MESSAGE_CLIENT_TYPE, LiQueryConstant.LI_MESSAGE_QUERYSETTINGS_TYPE, LiMessage.class).setReplacer(liQueryValueReplacer);
     }
 
     /**
      * Fetches details of all floated (or "pinned") of the specified board for the user in context.
-     * Create parameters with {@LiClientRequestParams.LiFloatedMessagesClientRequestParams}.
+     * Create parameters with {@link LiClientRequestParams.LiFloatedMessagesClientRequestParams}.
      *
-     * @param liClientRequestParams {@LiClientRequestParams.LiFloatedMessagesClientRequestParams} the Android context
-     *                              (required)
-     * @param liClientRequestParams the ID of the board (required)
-     * @param liClientRequestParams the scope for searching the floated messages. Supported scopes: "global", "local"
-     *                              (required)
+     * @param params the scope for searching the floated messages. Supported scopes: "global", "local"
+     *               (required)
      * @return LiFloatedMessageModel {@link LiFloatedMessageModel}
      * @throws LiRestResponseException {@link LiRestResponseException}
      */
-    public static LiClient getFloatedMessagesClient(
-            LiClientRequestParams liClientRequestParams) throws LiRestResponseException {
-        liClientRequestParams.validate(Client.LI_FLOATED_MESSAGES_CLIENT);
-        String boardId
-                = ((LiClientRequestParams.LiFloatedMessagesClientRequestParams) liClientRequestParams).getBoardId();
-        String scope = ((LiClientRequestParams.LiFloatedMessagesClientRequestParams) liClientRequestParams).getScope();
+    public static LiClient getFloatedMessagesClient(LiClientRequestParams params) throws LiRestResponseException {
+        params.validate(Client.LI_FLOATED_MESSAGES_CLIENT);
+        String boardId = ((LiClientRequestParams.LiFloatedMessagesClientRequestParams) params).getBoardId();
+        String scope = ((LiClientRequestParams.LiFloatedMessagesClientRequestParams) params).getScope();
         LiQueryValueReplacer liQueryValueReplacer = new LiQueryValueReplacer();
         liQueryValueReplacer.replaceAll("##", String.valueOf(boardId)).replaceAll("&&", scope);
-        return new LiBaseGetClient(liClientRequestParams.getContext(),
-                LiQueryConstant.LI_FLOATED_MESSAGE_CLIENT_BASE_LIQL, LiQueryConstant.LI_FLOATED_MESSAGE_CLIENT_TYPE,
-                LiQueryConstant.LI_FLOATED_MESSAGE_QUERYSETTINGS_TYPE, LiFloatedMessageModel.class).setReplacer(
-                liQueryValueReplacer);
+
+        return new LiBaseGetClient(params.getContext(), LiQueryConstant.LI_FLOATED_MESSAGE_CLIENT_BASE_LIQL,
+                LiQueryConstant.LI_FLOATED_MESSAGE_CLIENT_TYPE, LiQueryConstant.LI_FLOATED_MESSAGE_QUERYSETTINGS_TYPE, LiFloatedMessageModel.class)
+                .setReplacer(liQueryValueReplacer);
     }
 
     /**
-     * Fetches details for the specified set of messages. Create parameters with {@LiClientRequestParams
-     * .LiMessagesByIdsClientRequestParams}.
+     * Fetches details for the specified set of messages. Create parameters with {@link LiClientRequestParams.LiMessagesByIdsClientRequestParams}.
      *
-     * @param liClientRequestParams {@LiClientRequestParams.LiMessagesByIdsClientRequestParams} the Android context
-     *                              (required)
-     * @param liClientRequestParams the IDs of the messages, passed as a set (required)
+     * @param params {@link LiClientRequestParams.LiMessagesByIdsClientRequestParams}.
      * @return LiMessages {@link LiMessage}
      * @throws LiRestResponseException {@link LiRestResponseException}
      */
-    public static LiClient getMessagesByIdsClient(
-            LiClientRequestParams liClientRequestParams) throws LiRestResponseException {
-        liClientRequestParams.validate(Client.LI_MESSAGES_BY_ID_CLIENT);
-        Set<String> messageIds
-                = ((LiClientRequestParams.LiMessagesByIdsClientRequestParams) liClientRequestParams).getMessageIds();
+    public static LiClient getMessagesByIdsClient(LiClientRequestParams params) throws LiRestResponseException {
+        params.validate(Client.LI_MESSAGES_BY_ID_CLIENT);
+        Set<String> messageIds = ((LiClientRequestParams.LiMessagesByIdsClientRequestParams) params).getMessageIds();
         final StringBuilder sb = new StringBuilder();
         boolean isFirst = true;
         for (String id : messageIds) {
@@ -395,28 +343,25 @@ public class LiClientManager {
         LiQueryValueReplacer liQueryValueReplacer = new LiQueryValueReplacer();
         liQueryValueReplacer.replaceAll("##", sb.toString());
 
-        return new LiBaseGetClient(liClientRequestParams.getContext(), LiQueryConstant.LI_MESSAGE_LIST_BASE_LIQL,
-                LiQueryConstant.LI_MESSAGE_CLIENT_TYPE, LiQueryConstant.LI_MESSAGE_BY_IDS_QUERYSETTINGS_TYPE,
-                LiMessage.class).setReplacer(liQueryValueReplacer);
+        return new LiBaseGetClient(params.getContext(), LiQueryConstant.LI_MESSAGE_LIST_BASE_LIQL, LiQueryConstant.LI_MESSAGE_CLIENT_TYPE,
+                LiQueryConstant.LI_MESSAGE_BY_IDS_QUERYSETTINGS_TYPE, LiMessage.class).setReplacer(liQueryValueReplacer);
     }
 
     /**
-     * Kudos the specified message for the user in context.
-     * Create parameters with {@link LiClientRequestParams.LiKudoClientRequestParams}.
-     * Uses {@link LiPostKudoModel} to build the request body. The model is converted to a JsonObject, which is then
-     * used in the POST call.
+     * Kudos the specified message for the user in context. Create parameters with {@link LiClientRequestParams.LiKudoClientRequestParams}.
+     * Uses {@link LiPostKudoModel} to build the request body. The model is converted to a JsonObject, which is then used in the POST call.
      *
-     * @param liClientRequestParams {@link LiClientRequestParams.LiKudoClientRequestParams} the Android context
-     *                              (required)
-     * @param liClientRequestParams the ID of the message to kudo (required)
+     * @param params the ID of the message to kudo (required)
      * @return LiClient {@link LiClient}
      * @throws LiRestResponseException {@link LiRestResponseException}
      */
-    public static LiClient getKudoClient(LiClientRequestParams liClientRequestParams) throws LiRestResponseException {
-        liClientRequestParams.validate(Client.LI_KUDO_CLIENT);
-        String messageId = ((LiClientRequestParams.LiKudoClientRequestParams) liClientRequestParams).getMessageId();
-        final LiBasePostClient liBasePostClient = new LiBasePostClient(liClientRequestParams.getContext(),
-                String.format("/community/2.0/%s/messages/%s/kudos", LiSDKManager.getInstance().getTenant(), messageId));
+    public static LiClient getKudoClient(LiClientRequestParams params) throws LiRestResponseException {
+
+        params.validate(Client.LI_KUDO_CLIENT);
+        String messageId = ((LiClientRequestParams.LiKudoClientRequestParams) params).getMessageId();
+        final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(), String.format("/community/2.0/%s/messages/%s/kudos",
+                LiSDKManager.getInstance().getTenant(), messageId));
+
         LiPostKudoModel liPostKudoModel = new LiPostKudoModel();
         LiMessage liMessage = new LiMessage();
         LiBaseModelImpl.LiInt liInt = new LiBaseModelImpl.LiInt();
@@ -425,77 +370,69 @@ public class LiClientManager {
         liPostKudoModel.setType(LiQueryConstant.LI_KUDO_TYPE);
         liPostKudoModel.setMessage(liMessage);
         liBasePostClient.postModel = liPostKudoModel;
+
         return liBasePostClient;
     }
 
     /**
-     * Unkudos the specified message for the user in context.
-     * Create parameters with {@link LiClientRequestParams.LiUnKudoClientRequestParams}.
-     * Uses {@link LiPostKudoModel} to build the request body. The model is converted to a JsonObject, which is then
-     * used in the POST call.
+     * Unkudos the specified message for the user in context. Create parameters with {@link LiClientRequestParams.LiUnKudoClientRequestParams}.
+     * Uses {@link LiPostKudoModel} to build the request body. The model is converted to a JsonObject, which is then used in the POST call.
      *
-     * @param liClientRequestParams {@link LiClientRequestParams.LiUnKudoClientRequestParams} the Android context
-     *                              (required)
-     * @param liClientRequestParams the ID of the message to unkudoed (required)
+     * @param params the ID of the message to unkudoed (required)
      * @return LiClient {@link LiClient}
      * @throws LiRestResponseException {@link LiRestResponseException}
      */
-    public static LiClient getUnKudoClient(LiClientRequestParams liClientRequestParams) throws LiRestResponseException {
-        liClientRequestParams.validate(Client.LI_UNKUDO_CLIENT);
-        String messageId = ((LiClientRequestParams.LiUnKudoClientRequestParams) liClientRequestParams).getMessageId();
-        LiClientRequestParams.LiGenericDeleteClientRequestParams requestParams =
-                new LiClientRequestParams.LiGenericDeleteClientRequestParams(liClientRequestParams.getContext(), CollectionsType.MESSAGE, messageId, "/kudos");
+    public static LiClient getUnKudoClient(LiClientRequestParams params) throws LiRestResponseException {
+        params.validate(Client.LI_UNKUDO_CLIENT);
+        String messageId = ((LiClientRequestParams.LiUnKudoClientRequestParams) params).getMessageId();
+        LiClientRequestParams.LiGenericDeleteClientRequestParams requestParams = new LiClientRequestParams.LiGenericDeleteClientRequestParams(
+                params.getContext(), CollectionsType.MESSAGE, messageId, "/kudos");
+
         return getGenericQueryDeleteClient(requestParams);
     }
 
     /**
-     * Marks a message as an accepted solution.
-     * Create parameters with {@link LiClientRequestParams.LiAcceptSolutionClientRequestParams}.
-     * Uses {@link LiAcceptSolutionModel} to build the request body. The model is converted to a JsonObject, which is
-     * then used in the POST call.
+     * Marks a message as an accepted solution. Create parameters with {@link LiClientRequestParams.LiAcceptSolutionClientRequestParams}.
+     * Uses {@link LiAcceptSolutionModel} to build the request body. The model is converted to a JsonObject, which is then used in the POST call.
      *
-     * @param liClientRequestParams {@link LiClientRequestParams.LiAcceptSolutionClientRequestParams} the Android
-     *                              context (required)
-     * @param liClientRequestParams the ID of the message to mark as a solution (required)
+     * @param params the ID of the message to mark as a solution (required)
      * @return LiClient {@link LiClient}
      * @throws LiRestResponseException {@link LiRestResponseException}
      */
-    public static LiClient getAcceptSolutionClient(LiClientRequestParams liClientRequestParams) throws LiRestResponseException {
-        liClientRequestParams.validate(Client.LI_ACCEPT_SOLUTION_CLIENT);
-        Long messageId = ((LiClientRequestParams.LiAcceptSolutionClientRequestParams) liClientRequestParams).getMessageId();
-        LiBasePostClient liBasePostClient = new LiBasePostClient(liClientRequestParams.getContext(),
+    public static LiClient getAcceptSolutionClient(LiClientRequestParams params) throws LiRestResponseException {
+        params.validate(Client.LI_ACCEPT_SOLUTION_CLIENT);
+        Long messageId = ((LiClientRequestParams.LiAcceptSolutionClientRequestParams) params).getMessageId();
+        LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(),
                 String.format("/community/2.0/%s/solutions_data", LiSDKManager.getInstance().getTenant()));
         LiAcceptSolutionModel liAcceptSolutionModel = new LiAcceptSolutionModel();
         liAcceptSolutionModel.setType(LiQueryConstant.LI_ACCEPT_SOLUTION_TYPE);
         liAcceptSolutionModel.setMessageid(String.valueOf(messageId));
         liBasePostClient.postModel = liAcceptSolutionModel;
+
         return liBasePostClient;
     }
 
     /**
-     * Posts a new message to the community.
-     * Create parameters with {@link LiClientRequestParams.LiCreateMessageClientRequestParams}.
-     * Uses {@link LiPostMessageModel} to build the request body. The model is converted to a JsonObject, which is
-     * then used in the POST call.
+     * Posts a new message to the community. Create parameters with {@link LiClientRequestParams.LiCreateMessageClientRequestParams}.
+     * Uses {@link LiPostMessageModel} to build the request body. The model is converted to a JsonObject, which is then used in the POST call.
      *
-     * @param liClientRequestParams {@link LiClientRequestParams.LiCreateMessageClientRequestParams} the Android
-     *                              context (required)
-     * @param liClientRequestParams the subject of the message (required)
-     * @param liClientRequestParams the body of the message (required)
-     * @param liClientRequestParams the image filename (if an image is included in the message)
-     * @param liClientRequestParams the image ID (if an image is included in the message)
-     * @param liClientRequestParams the ID of the board where the message will be posted (required)
+     * @param params {@link LiClientRequestParams.LiCreateMessageClientRequestParams}
+     *               the subject of the message (required)
+     *               the body of the message (required)
+     *               the image filename (if an image is included in the message)
+     *               the image ID (if an image is included in the message)
+     *               the ID of the board where the message will be posted (required)
      * @return LiClient {@link LiClient}
      * @throws LiRestResponseException {@link LiRestResponseException}
      */
-    public static LiClient getCreateMessageClient(LiClientRequestParams liClientRequestParams) throws LiRestResponseException {
-        liClientRequestParams.validate(Client.LI_CREATE_MESSAGE_CLIENT);
-        final String subject = ((LiClientRequestParams.LiCreateMessageClientRequestParams) liClientRequestParams).getSubject();
-        final String boardId = ((LiClientRequestParams.LiCreateMessageClientRequestParams) liClientRequestParams).getBoardId();
-        final String imageId = ((LiClientRequestParams.LiCreateMessageClientRequestParams) liClientRequestParams).getImageId();
-        final String imageName = ((LiClientRequestParams.LiCreateMessageClientRequestParams) liClientRequestParams).getImageName();
+    public static LiClient getCreateMessageClient(LiClientRequestParams params) throws LiRestResponseException {
+        params.validate(Client.LI_CREATE_MESSAGE_CLIENT);
+        final String subject = ((LiClientRequestParams.LiCreateMessageClientRequestParams) params).getSubject();
+        final String boardId = ((LiClientRequestParams.LiCreateMessageClientRequestParams) params).getBoardId();
+        final String imageId = ((LiClientRequestParams.LiCreateMessageClientRequestParams) params).getImageId();
+        final String imageName = ((LiClientRequestParams.LiCreateMessageClientRequestParams) params).getImageName();
 
-        final LiBasePostClient liBasePostClient = new LiBasePostClient(liClientRequestParams.getContext(),
+        final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(),
                 String.format("/community/2.0/%s/messages", LiSDKManager.getInstance().getTenant()));
 
         LiPostMessageModel liPostMessageModel = new LiPostMessageModel();
@@ -506,49 +443,46 @@ public class LiClientManager {
         liPostMessageModel.setType(LiQueryConstant.LI_POST_QUESTION_TYPE);
         liPostMessageModel.setSubject(subject);
 
-        String body = ((LiClientRequestParams.LiCreateMessageClientRequestParams) liClientRequestParams).getBody();
+        String body = ((LiClientRequestParams.LiCreateMessageClientRequestParams) params).getBody();
         body = embedImageTag(body, imageId, imageName);
         liPostMessageModel.setBody(body);
         liPostMessageModel.setBoard(liBoard);
         liBasePostClient.postModel = liPostMessageModel;
+
         return liBasePostClient;
     }
 
     /**
-     * Updates an existing message by ID. Crate parameters with
-     * {@link LiClientRequestParams.LiUpdateMessageClientRequestParams}.
-     * Uses {@link LiPostMessageModel} to build the request body. The model is converted to a JsonObject, which is
-     * then used in the PUT call.
+     * Updates an existing message by ID. Crate parameters with {@link LiClientRequestParams.LiUpdateMessageClientRequestParams}.
+     * Uses {@link LiPostMessageModel} to build the request body. The model is converted to a JsonObject, which is then used in the PUT call.
      *
-     * @param liClientRequestParams {@link LiClientRequestParams.LiUpdateMessageClientRequestParams} the Android
-     *                              context (required)
-     * @param liClientRequestParams the message subject
-     * @param liClientRequestParams the message body
-     * @param liClientRequestParams the message ID (required)
+     * @param params {@link LiClientRequestParams.LiUpdateMessageClientRequestParams}
+     *               the Android context (required)
+     *               the message subject
+     *               the message body
+     *               the message ID (required)
      * @return LiClient {@link LiClient}
      * @throws LiRestResponseException {@link LiRestResponseException}
      */
-    public static LiClient getUpdateMessageClient(LiClientRequestParams liClientRequestParams) throws LiRestResponseException {
-        liClientRequestParams.validate(Client.LI_UPDATE_MESSAGE_CLIENT);
-        final String subject = ((LiClientRequestParams.LiUpdateMessageClientRequestParams) liClientRequestParams).getSubject();
-        final String body = ((LiClientRequestParams.LiUpdateMessageClientRequestParams) liClientRequestParams).getBody();
-        final String messageId = ((LiClientRequestParams.LiUpdateMessageClientRequestParams) liClientRequestParams).getMessageId();
+    public static LiClient getUpdateMessageClient(LiClientRequestParams params) throws LiRestResponseException {
+        params.validate(Client.LI_UPDATE_MESSAGE_CLIENT);
+        final String subject = ((LiClientRequestParams.LiUpdateMessageClientRequestParams) params).getSubject();
+        final String body = ((LiClientRequestParams.LiUpdateMessageClientRequestParams) params).getBody();
+        final String messageId = ((LiClientRequestParams.LiUpdateMessageClientRequestParams) params).getMessageId();
 
-        final LiBasePutClient liBasePutClient = new LiBasePutClient(liClientRequestParams.getContext(),
+        final LiBasePutClient liBasePutClient = new LiBasePutClient(params.getContext(),
                 String.format("/community/2.0/%s/messages/%s", LiSDKManager.getInstance().getTenant(), messageId));
         LiPostMessageModel liPostMessageModel = new LiPostMessageModel();
         liPostMessageModel.setType(LI_POST_QUESTION_TYPE);
         liPostMessageModel.setBody(body);
         liPostMessageModel.setSubject(subject);
         liBasePutClient.postModel = liPostMessageModel;
+
         return liBasePutClient;
     }
 
     /**
      * Embeds an image tag into the message body.
-     * <p><li-image id=IMAGEID</> width="500" height="500" alt=IAMGEID.png align="inline" size="large"
-     * sourcetype="new"></li-image></p>
-     * //This is to insert image id in body if any to effectively display image along with post.
      *
      * @param body      Body of the message to which image has to be attached
      * @param imageId   Id of the image received from community.
@@ -566,27 +500,25 @@ public class LiClientManager {
     }
 
     /**
-     * Creates a reply or comment.
-     * Create parameters with {@link LiClientRequestParams.LiCreateReplyClientRequestParams}.
-     * Uses {@link LiReplyMessageModel} to build request body. The model is converted to a JsonObject, which is then
-     * used in the POST call.
+     * Creates a reply or comment. Create parameters with {@link LiClientRequestParams.LiCreateReplyClientRequestParams}.
+     * Uses {@link LiReplyMessageModel} to build request body. The model is converted to a JsonObject, which is then used in the POST call.
      *
-     * @param liClientRequestParams {@link LiClientRequestParams.LiCreateReplyClientRequestParams} the Android
-     *                              context (required)
-     * @param liClientRequestParams the message ID (required)
-     * @param liClientRequestParams the message body (required)
-     * @param liClientRequestParams the image filename (if the message includes an image)
-     * @param liClientRequestParams the image ID (if the message includes an image)
+     * @param params {@link LiClientRequestParams.LiCreateReplyClientRequestParams}
+     *               the Android context (required)
+     *               the message ID (required)
+     *               the message body (required)
+     *               the image filename (if the message includes an image)
+     *               the image ID (if the message includes an image)
      * @return LiClient {@link LiClient}
      * @throws LiRestResponseException LiClient {@link LiRestResponseException}
      */
-    public static LiClient getCreateReplyClient(LiClientRequestParams liClientRequestParams) throws LiRestResponseException {
-        liClientRequestParams.validate(Client.LI_CREATE_REPLY_CLIENT);
-        final String subject = ((LiClientRequestParams.LiCreateReplyClientRequestParams) liClientRequestParams).getSubject();
-        final Long messageId = ((LiClientRequestParams.LiCreateReplyClientRequestParams) liClientRequestParams).getMessageId();
-        final String imageId = ((LiClientRequestParams.LiCreateReplyClientRequestParams) liClientRequestParams).getImageId();
-        final String imageName = ((LiClientRequestParams.LiCreateReplyClientRequestParams) liClientRequestParams).getImageName();
-        final LiBasePostClient liBasePostClient = new LiBasePostClient(liClientRequestParams.getContext(),
+    public static LiClient getCreateReplyClient(LiClientRequestParams params) throws LiRestResponseException {
+        params.validate(Client.LI_CREATE_REPLY_CLIENT);
+        final String subject = ((LiClientRequestParams.LiCreateReplyClientRequestParams) params).getSubject();
+        final Long messageId = ((LiClientRequestParams.LiCreateReplyClientRequestParams) params).getMessageId();
+        final String imageId = ((LiClientRequestParams.LiCreateReplyClientRequestParams) params).getImageId();
+        final String imageName = ((LiClientRequestParams.LiCreateReplyClientRequestParams) params).getImageName();
+        final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(),
                 String.format("/community/2.0/%s/messages", LiSDKManager.getInstance().getTenant()));
 
         final LiReplyMessageModel liReplyMessage = new LiReplyMessageModel();
@@ -595,7 +527,7 @@ public class LiClientManager {
         liId.setValue(Long.valueOf(messageId));
         parent.setId(liId);
 
-        String body = ((LiClientRequestParams.LiCreateReplyClientRequestParams) liClientRequestParams).getBody();
+        String body = ((LiClientRequestParams.LiCreateReplyClientRequestParams) params).getBody();
         body = embedImageTag(body, imageId, imageName);
         liReplyMessage.setSubject(subject);
         liReplyMessage.setBody(body);
@@ -607,30 +539,28 @@ public class LiClientManager {
     }
 
     /**
-     * Uploads an image to the community on behalf of the user in context. The image is placed into the user's public
-     * album.
+     * Uploads an image to the community on behalf of the user in context. The image is placed into the user's public album.
      * Create parameters with {@link LiClientRequestParams.LiUploadImageClientRequestParams}.
-     * Uses {@link LiUploadImageModel} to build request body. The model is converted to a JsonObject, which is then
-     * used in the POST call.
+     * Uses {@link LiUploadImageModel} to build request body. The model is converted to a JsonObject, which is then used in the POST call.
      *
-     * @param liClientRequestParams {@link LiClientRequestParams.LiUploadImageClientRequestParams} the Android
-     *                              context (required)
-     * @param liClientRequestParams the image title (required)
-     * @param liClientRequestParams the image filename (required)
-     * @param liClientRequestParams the absolute path to the image (required)
-     *                              Note: the image filename and the filename in the absolute path param above must
-     *                              be equal.
+     * @param params {@link LiClientRequestParams.LiUploadImageClientRequestParams}
+     *               the Android context (required)
+     *               the image title (required)
+     *               the image filename (required)
+     *               the absolute path to the image (required)
+     *               Note: the image filename and the filename in the absolute path param above must
+     *               be equal.
      * @return LiClient {@link LiClient}
      * @throws LiRestResponseException {@link LiRestResponseException}
      */
-    public static LiClient getUploadImageClient(LiClientRequestParams liClientRequestParams) throws LiRestResponseException {
-        liClientRequestParams.validate(Client.LI_UPLOAD_IMAGE_CLIENT);
+    public static LiClient getUploadImageClient(LiClientRequestParams params) throws LiRestResponseException {
+        params.validate(Client.LI_UPLOAD_IMAGE_CLIENT);
 
-        final String title = ((LiClientRequestParams.LiUploadImageClientRequestParams) liClientRequestParams).getTitle();
-        final String description = ((LiClientRequestParams.LiUploadImageClientRequestParams) liClientRequestParams).getDescription();
-        final String imageName = ((LiClientRequestParams.LiUploadImageClientRequestParams) liClientRequestParams).getImageName();
-        final String path = ((LiClientRequestParams.LiUploadImageClientRequestParams) liClientRequestParams).getPath();
-        final LiBasePostClient liBasePostClient = new LiBasePostClient(liClientRequestParams.getContext(),
+        final String title = ((LiClientRequestParams.LiUploadImageClientRequestParams) params).getTitle();
+        final String description = ((LiClientRequestParams.LiUploadImageClientRequestParams) params).getDescription();
+        final String imageName = ((LiClientRequestParams.LiUploadImageClientRequestParams) params).getImageName();
+        final String path = ((LiClientRequestParams.LiUploadImageClientRequestParams) params).getPath();
+        final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(),
                 String.format("/community/2.0/%s/images", LiSDKManager.getInstance().getTenant()), path, imageName);
 
         LiUploadImageModel uploadImageModel = new LiUploadImageModel();
@@ -645,28 +575,24 @@ public class LiClientManager {
     }
 
     /**
-     * Creates an abuse report for the specified message.
-     * Create parameters with {@link LiClientRequestParams.LiReportAbuseClientRequestParams}.
-     * Uses the {@link LiMarkAbuseModel} to build the request body. The model is converted to a JsonObject, which is
-     * then used in the POST call.
-     * <p>
-     * Added 1.0.2
+     * Creates an abuse report for the specified message. Create parameters with {@link LiClientRequestParams.LiReportAbuseClientRequestParams}.
+     * Uses the {@link LiMarkAbuseModel} to build the request body. The model is converted to a JsonObject, which is then used in the POST call.
      *
-     * @param liClientRequestParams {@link LiClientRequestParams.LiReportAbuseClientRequestParams} the Android
-     *                              context (required)
-     * @param liClientRequestParams the ID of message to report (required)
-     * @param liClientRequestParams the message body of the message being reported (required)
-     * @param liClientRequestParams the ID of the user making the abuse report (required)
+     * @param params {@link LiClientRequestParams.LiReportAbuseClientRequestParams}
+     *               the Android context (required)
+     *               the ID of message to report (required)
+     *               the message body of the message being reported (required)
+     *               the ID of the user making the abuse report (required)
      * @return {@link LiClient}
      * @throws LiRestResponseException {@link LiRestResponseException}
      */
-    public static LiClient getReportAbuseClient(LiClientRequestParams liClientRequestParams) throws LiRestResponseException {
-        liClientRequestParams.validate(Client.LI_MARK_ABUSE_CLIENT);
+    public static LiClient getReportAbuseClient(LiClientRequestParams params) throws LiRestResponseException {
+        params.validate(Client.LI_MARK_ABUSE_CLIENT);
 
-        final String messageId = ((LiClientRequestParams.LiReportAbuseClientRequestParams) liClientRequestParams).getMessageId();
-        final String userId = ((LiClientRequestParams.LiReportAbuseClientRequestParams) liClientRequestParams).getUserId();
-        final String body = ((LiClientRequestParams.LiReportAbuseClientRequestParams) liClientRequestParams).getBody();
-        final LiBasePostClient liBasePostClient = new LiBasePostClient(liClientRequestParams.getContext(),
+        final String messageId = ((LiClientRequestParams.LiReportAbuseClientRequestParams) params).getMessageId();
+        final String userId = ((LiClientRequestParams.LiReportAbuseClientRequestParams) params).getUserId();
+        final String body = ((LiClientRequestParams.LiReportAbuseClientRequestParams) params).getBody();
+        final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(),
                 String.format("/community/2.0/%s/abuse_reports", LiSDKManager.getInstance().getTenant()));
 
         LiMarkAbuseModel liMarkAbuseModel = new LiMarkAbuseModel();
@@ -689,24 +615,21 @@ public class LiClientManager {
     }
 
     /**
-     * Fetches the ID corresponding to device ID from the community.
-     * Create parameters with {@link LiClientRequestParams.LiDeviceIdFetchClientRequestParams}.
+     * Fetches the ID corresponding to device ID from the community. Create parameters with {@link LiClientRequestParams.LiDeviceIdFetchClientRequestParams}.
      *
-     * @param liClientRequestParams {@link LiClientRequestParams.LiDeviceIdFetchClientRequestParams} the ID
-     *                              registered with
-     *                              notification
-     *                              provider
-     * @param liClientRequestParams the Global provider for Push notification. Currently "GCM" and "FIREBASE".
+     * @param params {@link LiClientRequestParams.LiDeviceIdFetchClientRequestParams}
+     *               the ID registered with notification provider
+     *               the Global provider for Push notification. Currently "GCM" and "FIREBASE".
      * @return {@link LiClient}
      * @throws LiRestResponseException {@link LiRestResponseException}
      */
-    public static LiClient getDeviceIdFetchClient(LiClientRequestParams liClientRequestParams) throws LiRestResponseException {
-        liClientRequestParams.validate(Client.LI_DEVICE_ID_FETCH_CLIENT);
+    public static LiClient getDeviceIdFetchClient(LiClientRequestParams params) throws LiRestResponseException {
+        params.validate(Client.LI_DEVICE_ID_FETCH_CLIENT);
 
-        final String deviceId = ((LiClientRequestParams.LiDeviceIdFetchClientRequestParams) liClientRequestParams).getDeviceId();
-        final String pushNotificationProvider = ((LiClientRequestParams.LiDeviceIdFetchClientRequestParams) liClientRequestParams)
+        final String deviceId = ((LiClientRequestParams.LiDeviceIdFetchClientRequestParams) params).getDeviceId();
+        final String pushNotificationProvider = ((LiClientRequestParams.LiDeviceIdFetchClientRequestParams) params)
                 .getPushNotificationProvider();
-        final LiBasePostClient liBasePostClient = new LiBasePostClient(liClientRequestParams.getContext(),
+        final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(),
                 String.format("/community/2.0/%s/user_device_data", LiSDKManager.getInstance().getTenant()));
 
         final LiUserDeviceDataModel liUserDeviceDataModel = new LiUserDeviceDataModel();
@@ -721,56 +644,49 @@ public class LiClientManager {
     }
 
     /**
-     * Updates the device ID in community with the given device ID. Create parameters with
-     * {@link LiClientRequestParams.LiDeviceIdUpdateClientRequestParams}.
+     * Updates the device ID in community with the given device ID. Create parameters with {@link LiClientRequestParams.LiDeviceIdUpdateClientRequestParams}.
      *
-     * @param liClientRequestParams {@link LiClientRequestParams.LiDeviceIdUpdateClientRequestParams} the Android
-     *                              context (required)
-     * @param liClientRequestParams the device ID registered with the push notification provider (required)
-     * @param liClientRequestParams the ID corresponding to device ID in the community (required)
+     * @param params {@link LiClientRequestParams.LiDeviceIdUpdateClientRequestParams}
+     *               the Android context (required)
+     *               the device ID registered with the push notification provider (required)
+     *               the ID corresponding to device ID in the community (required)
      * @return {@link LiClient}
      * @throws LiRestResponseException {@link LiRestResponseException}
      */
-    public static LiClient getDeviceIdUpdateClient(
-            LiClientRequestParams liClientRequestParams) throws LiRestResponseException {
-        liClientRequestParams.validate(Client.LI_DEVICE_ID_UPDATE_CLIENT);
-        String deviceId
-                = ((LiClientRequestParams.LiDeviceIdUpdateClientRequestParams) liClientRequestParams).getDeviceId();
-        String id = ((LiClientRequestParams.LiDeviceIdUpdateClientRequestParams) liClientRequestParams).getDeviceId();
+    public static LiClient getDeviceIdUpdateClient(LiClientRequestParams params) throws LiRestResponseException {
+        params.validate(Client.LI_DEVICE_ID_UPDATE_CLIENT);
+        String deviceId = ((LiClientRequestParams.LiDeviceIdUpdateClientRequestParams) params).getDeviceId();
+        String id = ((LiClientRequestParams.LiDeviceIdUpdateClientRequestParams) params).getDeviceId();
         String path = "/community/2.0/%s/user_device_data/" + id;
-        LiBasePutClient liBasePostClient = new LiBasePutClient(liClientRequestParams.getContext(),
-                String.format(path,
-                        LiSDKManager.getInstance().getTenant()));
+        LiBasePutClient liBasePostClient = new LiBasePutClient(params.getContext(), String.format(path, LiSDKManager.getInstance().getTenant()));
         LiUserDeviceIdUpdateModel liUserDeviceIdUpdateModel = new LiUserDeviceIdUpdateModel();
         liUserDeviceIdUpdateModel.setType(LiQueryConstant.LI_USER_DEVICE_ID_FETCH_TYPE);
         liUserDeviceIdUpdateModel.setDeviceId(deviceId);
         liBasePostClient.postModel = liUserDeviceIdUpdateModel;
+
         return liBasePostClient;
     }
 
     /**
-     * Creates new user account.
-     * Create parameters with {@link LiClientRequestParams.LiCreateUserParams}.
-     * Uses {@link LiCreateUpdateUserModel} to build the request body. The model is converted to a JsonObject, which
-     * is then used in the POST call.
-     * <p>
-     * Added 1.1.0
+     * Creates new user account. Create parameters with {@link LiClientRequestParams.LiCreateUserParams}.
+     * Uses {@link LiCreateUpdateUserModel} to build the request body. The model is converted to a JsonObject, which is then used in the POST call.
      *
-     * @param liClientRequestParams {@link LiClientRequestParams.LiCreateUserParams} the Android context (required)
-     * @param liClientRequestParams the user's login (required)
-     * @param liClientRequestParams the user's password (required)
-     * @param liClientRequestParams the user's email (required)
-     * @param liClientRequestParams the user's avatar
-     * @param liClientRequestParams the user's biography
-     * @param liClientRequestParams the user's first name
-     * @param liClientRequestParams the user's last name
+     * @param params {@link LiClientRequestParams.LiCreateUserParams}
+     *               the Android context (required)
+     *               the user's login (required)
+     *               the user's password (required)
+     *               the user's email (required)
+     *               the user's avatar
+     *               the user's biography
+     *               the user's first name
+     *               the user's last name
      * @return {@link LiClient}
      * @throws LiRestResponseException
      */
-    public static LiClient getCreateUserClient(LiClientRequestParams liClientRequestParams) throws LiRestResponseException {
-        liClientRequestParams.validate(Client.LI_CREATE_USER_CLIENT);
+    public static LiClient getCreateUserClient(LiClientRequestParams params) throws LiRestResponseException {
+        params.validate(Client.LI_CREATE_USER_CLIENT);
 
-        final LiClientRequestParams.LiCreateUserParams liCreateUserParams = ((LiClientRequestParams.LiCreateUserParams) liClientRequestParams);
+        final LiClientRequestParams.LiCreateUserParams liCreateUserParams = ((LiClientRequestParams.LiCreateUserParams) params);
         final LiAvatar avatar = new LiAvatar();
 
         if (!TextUtils.isEmpty(liCreateUserParams.getAvatarUrl())) {
@@ -786,15 +702,15 @@ public class LiClientManager {
             avatar.setImage(liCreateUserParams.getAvatarImageId());
         }
 
-        final String biography = ((LiClientRequestParams.LiCreateUserParams) liClientRequestParams).getBiography();
-        final String coverImage = ((LiClientRequestParams.LiCreateUserParams) liClientRequestParams).getCoverImage();
-        final String email = ((LiClientRequestParams.LiCreateUserParams) liClientRequestParams).getEmail();
-        final String firstName = ((LiClientRequestParams.LiCreateUserParams) liClientRequestParams).getFirstName();
-        final String lastName = ((LiClientRequestParams.LiCreateUserParams) liClientRequestParams).getLastName();
-        final String login = ((LiClientRequestParams.LiCreateUserParams) liClientRequestParams).getLogin();
-        final String password = ((LiClientRequestParams.LiCreateUserParams) liClientRequestParams).getPassword();
+        final String biography = ((LiClientRequestParams.LiCreateUserParams) params).getBiography();
+        final String coverImage = ((LiClientRequestParams.LiCreateUserParams) params).getCoverImage();
+        final String email = ((LiClientRequestParams.LiCreateUserParams) params).getEmail();
+        final String firstName = ((LiClientRequestParams.LiCreateUserParams) params).getFirstName();
+        final String lastName = ((LiClientRequestParams.LiCreateUserParams) params).getLastName();
+        final String login = ((LiClientRequestParams.LiCreateUserParams) params).getLogin();
+        final String password = ((LiClientRequestParams.LiCreateUserParams) params).getPassword();
 
-        final LiBasePostClient liBasePostClient = new LiBasePostClient(liClientRequestParams.getContext(),
+        final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(),
                 String.format("/community/2.0/%s/users", LiSDKManager.getInstance().getTenant()));
 
         final LiCreateUpdateUserModel liCreateUpdateUserModel = new LiCreateUpdateUserModel();
@@ -813,29 +729,25 @@ public class LiClientManager {
     }
 
     /**
-     * Mark a single message as read or unread
-     * Create parameters with {@link LiClientRequestParams.LiMarkMessageParams}.
-     * Uses the {@link LiMarkMessageModel} to build the request body. The model is converted to a JsonObject, which
-     * is then used in the POST call.
-     * <p>
-     * Added 1.1.0
+     * Mark a single message as read or unread Create parameters with {@link LiClientRequestParams.LiMarkMessageParams}.
+     * Uses the {@link LiMarkMessageModel} to build the request body. The model is converted to a JsonObject, which is then used in the POST call.
      *
-     * @param liClientRequestParams {@link LiClientRequestParams.LiMarkMessageParams} the Android context (required)
-     * @param liClientRequestParams the ID of the user marking the message (required)
-     * @param liClientRequestParams the ID of the message (required)
-     * @param liClientRequestParams whether to mark the message read or unread. Pass 'markUnread' as 'true' to mark
-     *                              the message as read. (required)
+     * @param params {@link LiClientRequestParams.LiMarkMessageParams}
+     *               the Android context (required)
+     *               the ID of the user marking the message (required)
+     *               the ID of the message (required)
+     *               whether to mark the message read or unread. Pass 'markUnread' as 'true' to mark the message as read. (required)
      * @return {@link LiClient}
      * @throws LiRestResponseException
      */
-    public static LiClient getMarkMessagePostClient(LiClientRequestParams liClientRequestParams) throws LiRestResponseException {
-        liClientRequestParams.validate(Client.LI_MARK_MESSAGE_POST_CLIENT);
+    public static LiClient getMarkMessagePostClient(LiClientRequestParams params) throws LiRestResponseException {
+        params.validate(Client.LI_MARK_MESSAGE_POST_CLIENT);
 
-        final String userId = ((LiClientRequestParams.LiMarkMessageParams) liClientRequestParams).getUserId();
-        final String messageId = ((LiClientRequestParams.LiMarkMessageParams) liClientRequestParams).getMessageId();
-        final boolean markUnread = ((LiClientRequestParams.LiMarkMessageParams) liClientRequestParams).isMarkUnread();
+        final String userId = ((LiClientRequestParams.LiMarkMessageParams) params).getUserId();
+        final String messageId = ((LiClientRequestParams.LiMarkMessageParams) params).getMessageId();
+        final boolean markUnread = ((LiClientRequestParams.LiMarkMessageParams) params).isMarkUnread();
 
-        final LiBasePostClient liBasePostClient = new LiBasePostClient(liClientRequestParams.getContext(),
+        final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(),
                 String.format("/community/2.0/%s/messages_read", LiSDKManager.getInstance().getTenant()));
 
         final LiMarkMessageModel liMarkMessageModel = new LiMarkMessageModel();
@@ -849,31 +761,26 @@ public class LiClientManager {
     }
 
     /**
-     * Marks a set of messages (not necessarily in the same thread) as read or unread. Compare this to
-     * getMarkTopicPostClient.
-     * Create parameters with
-     * {@link lithium.community.android.sdk.model.request.LiClientRequestParams.LiMarkMessagesParams}.
-     * Uses the {@link LiMarkMessagesModel} to build the request body. The model is converted to a JsonObject, which
-     * is then used in the POST call.
-     * <p>
-     * Added 1.1.0
+     * Marks a set of messages (not necessarily in the same thread) as read or unread. Compare this to getMarkTopicPostClient.
+     * Create parameters with {@link lithium.community.android.sdk.model.request.LiClientRequestParams.LiMarkMessagesParams}.
+     * Uses the {@link LiMarkMessagesModel} to build the request body. The model is converted to a JsonObject, which is then used in the POST call.
      *
-     * @param liClientRequestParams {@link LiClientRequestParams.LiMarkMessagesParams} the Android context
-     * @param liClientRequestParams the user marking the messages (required)
-     * @param liClientRequestParams the IDs of the messages to mark in a comma-separated list (required)
-     * @param liClientRequestParams whether to mark the messages read or unread. Pass 'markUnread' as 'true' to mark
-     *                              the messages as read. (required)
+     * @param params {@link LiClientRequestParams.LiMarkMessagesParams}
+     *               the Android context
+     *               the user marking the messages (required)
+     *               the IDs of the messages to mark in a comma-separated list (required)
+     *               whether to mark the messages read or unread. Pass 'markUnread' as 'true' to mark the messages as read. (required)
      * @return {@link LiClient}
      * @throws LiRestResponseException
      */
-    public static LiClient getMarkMessagesPostClient(LiClientRequestParams liClientRequestParams) throws LiRestResponseException {
-        liClientRequestParams.validate(Client.LI_MARK_MESSAGES_POST_CLIENT);
+    public static LiClient getMarkMessagesPostClient(LiClientRequestParams params) throws LiRestResponseException {
+        params.validate(Client.LI_MARK_MESSAGES_POST_CLIENT);
 
-        final String userId = ((LiClientRequestParams.LiMarkMessagesParams) liClientRequestParams).getUserId();
-        final String messageIds = ((LiClientRequestParams.LiMarkMessagesParams) liClientRequestParams).getMessageIds();
-        final boolean markUnread = ((LiClientRequestParams.LiMarkMessagesParams) liClientRequestParams).isMarkUnread();
+        final String userId = ((LiClientRequestParams.LiMarkMessagesParams) params).getUserId();
+        final String messageIds = ((LiClientRequestParams.LiMarkMessagesParams) params).getMessageIds();
+        final boolean markUnread = ((LiClientRequestParams.LiMarkMessagesParams) params).isMarkUnread();
 
-        final LiBasePostClient liBasePostClient = new LiBasePostClient(liClientRequestParams.getContext(),
+        final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(),
                 String.format("/community/2.0/%s/messages_read", LiSDKManager.getInstance().getTenant()));
 
         final LiMarkMessagesModel liMarkMessagesModel = new LiMarkMessagesModel();
@@ -887,28 +794,26 @@ public class LiClientManager {
     }
 
     /**
-     * Marks a topic message and all its replies as read or unread. Compare this to getMarkMessagesPostClient.
-     * Create parameters with {@link LiClientRequestParams.LiMarkTopicParams}.
-     * Uses the {@link LiMarkTopicModel} to build the request body. The model is converted to a JsonObject, which is
-     * then used in the POST call.
-     * <p>
-     * Added 1.1.0
+     * Marks a topic message and all its replies as read or unread. Compare this to getMarkMessagesPostClient. Create parameters with
+     * {@link LiClientRequestParams.LiMarkTopicParams}. Uses the {@link LiMarkTopicModel} to build the request body. The model is converted to a JsonObject,
+     * which is then used in the POST call.
      *
-     * @param liClientRequestParams {@link LiClientRequestParams.LiMarkTopicParams} the Android context (required)
-     * @param liClientRequestParams the ID of the topic message to mark (required)
-     * @param liClientRequestParams whether to mark the messages read or unread. Pass 'markUnread' as 'true' to mark
-     *                              the messages as read. (required)
+     * @param params {@link LiClientRequestParams.LiMarkTopicParams}
+     *               the Android context (required)
+     *               the ID of the topic message to mark (required)
+     *               whether to mark the messages read or unread. Pass 'markUnread' as 'true' to mark
+     *               the messages as read. (required)
      * @return {@link LiClient}
      * @throws LiRestResponseException
      */
-    public static LiClient getMarkTopicPostClient(LiClientRequestParams liClientRequestParams) throws LiRestResponseException {
-        liClientRequestParams.validate(Client.LI_MARK_TOPIC_POST_CLIENT);
+    public static LiClient getMarkTopicPostClient(LiClientRequestParams params) throws LiRestResponseException {
+        params.validate(Client.LI_MARK_TOPIC_POST_CLIENT);
 
-        final String userId = ((LiClientRequestParams.LiMarkTopicParams) liClientRequestParams).getUserId();
-        final String topicId = ((LiClientRequestParams.LiMarkTopicParams) liClientRequestParams).getTopicId();
-        final boolean markUnread = ((LiClientRequestParams.LiMarkTopicParams) liClientRequestParams).isMarkUnread();
+        final String userId = ((LiClientRequestParams.LiMarkTopicParams) params).getUserId();
+        final String topicId = ((LiClientRequestParams.LiMarkTopicParams) params).getTopicId();
+        final boolean markUnread = ((LiClientRequestParams.LiMarkTopicParams) params).isMarkUnread();
 
-        final LiBasePostClient liBasePostClient = new LiBasePostClient(liClientRequestParams.getContext(),
+        final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(),
                 String.format("/community/2.0/%s/messages_read", LiSDKManager.getInstance().getTenant()));
 
         LiMarkTopicModel liMarkTopicModel = new LiMarkTopicModel();
@@ -923,34 +828,28 @@ public class LiClientManager {
 
 
     /**
-     * Creates a subscription to the specified target (a board or message).
-     * Create parameters with {@link LiClientRequestParams.LiPostSubscriptionParams}.
      * <p>
-     * The parameters can either be a target which is a {@link LiBaseModel} in the form of {@link LiMessage} or
-     * {@link LiBrowse}
-     * which was selected to be subscribed to and needs to be passed in the constructor
+     * Creates a subscription to the specified target (a board or message). Create parameters with {@link LiClientRequestParams.LiPostSubscriptionParams}.
+     * </p>
      * <p>
-     * Alternatively in the parameters "message/boardId" and "type" need to be passed in the constructor.
-     * "type" is either "message" or "board" depending upon what was selected.
+     * The parameters can either be a target which is a {@link LiBaseModel} in the form of {@link LiMessage} or {@link LiBrowse} which was selected to be
+     * subscribed to and needs to be passed in the constructor Alternatively in the parameters "message/boardId" and "type" need to be passed in the
+     * constructor. "type" is either "message" or "board" depending upon what was selected. If both are set then the target takes precedence and string
+     * parameters are ignored.
+     * </p>
      * <p>
-     * If both are set then the target takes precedence and string parameters are ignored.
-     * <p>
-     * Uses the {@link LiSubscriptionPostModel} to build the request body.
-     * The model is converted to a JsonObject, which is then used in the POST call.
-     * <p>
-     * Added 1.0.1
+     * Uses the {@link LiSubscriptionPostModel} to build the request body. The model is converted to a JsonObject, which is then used in the POST call.
+     * </p>
      *
-     * @param liClientRequestParams {@link LiClientRequestParams.LiPostSubscriptionParams} the Android context
-     *                              (required)
-     * @param liClientRequestParams the target of the subscription -- a board or message (required)
+     * @param params {@link LiClientRequestParams.LiPostSubscriptionParams}
+     *               the Android context
+     *               the target of the subscription -- a board or message (required)
      * @return {@link LiClient}
      * @throws LiRestResponseException
      */
-    public static LiClient getSubscriptionPostClient(
-            LiClientRequestParams liClientRequestParams) throws LiRestResponseException {
-        liClientRequestParams.validate(Client.LI_SUBSCRIPTION_POST_CLIENT);
-        LiClientRequestParams.LiPostSubscriptionParams liPostSubscriptionParams =
-                ((LiClientRequestParams.LiPostSubscriptionParams) liClientRequestParams);
+    public static LiClient getSubscriptionPostClient(LiClientRequestParams params) throws LiRestResponseException {
+        params.validate(Client.LI_SUBSCRIPTION_POST_CLIENT);
+        LiClientRequestParams.LiPostSubscriptionParams liPostSubscriptionParams = ((LiClientRequestParams.LiPostSubscriptionParams) params);
         LiBaseModel liBaseModel = liPostSubscriptionParams.getTarget();
         LiSubscriptionPostModel.Target target = new LiSubscriptionPostModel.Target();
         String targetID = null;
@@ -960,7 +859,6 @@ public class LiClientManager {
                 LiMessage message = (LiMessage) liBaseModel.getModel();
                 targetType = "message";
                 targetID = String.valueOf(message.getId());
-
             } else if (liBaseModel.getModel() instanceof LiBrowse) {
                 LiBrowse board = (LiBrowse) liBaseModel.getModel();
                 targetType = "board";
@@ -972,12 +870,13 @@ public class LiClientManager {
         }
         target.setType(targetType);
         target.setId(targetID);
-        LiBasePostClient liBasePostClient = new LiBasePostClient(liClientRequestParams.getContext(),
+        LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(),
                 String.format("/community/2.0/%s/subscriptions", LiSDKManager.getInstance().getTenant()));
         LiSubscriptionPostModel liSubscriptionPostModel = new LiSubscriptionPostModel();
         liSubscriptionPostModel.setType(LI_SUBSCRIPTIONS_CLIENT_TYPE);
         liSubscriptionPostModel.setTarget(target);
         liBasePostClient.postModel = liSubscriptionPostModel;
+
         return liBasePostClient;
     }
 
@@ -985,9 +884,7 @@ public class LiClientManager {
         String finalBoardId = boardId;
         String boardPrefix = "board:";
         if (finalBoardId.contains(boardPrefix)) {
-            finalBoardId = finalBoardId.substring(
-                    finalBoardId.indexOf(boardPrefix) + boardPrefix.length(),
-                    finalBoardId.length());
+            finalBoardId = finalBoardId.substring(finalBoardId.indexOf(boardPrefix) + boardPrefix.length(), finalBoardId.length());
         }
 
         return finalBoardId;
@@ -996,48 +893,46 @@ public class LiClientManager {
     /**
      * Deletes a subscription.
      *
-     * @param liClientRequestParams {@link LiClientRequestParams.LiDeleteSubscriptionParams} the Android context
-     * @param liClientRequestParams the subscription ID
+     * @param params {@link LiClientRequestParams.LiDeleteSubscriptionParams}
+     *               the Android context
+     *               the subscription ID
      * @return {@link LiClient}
      * @throws LiRestResponseException
      */
-    public static LiClient getSubscriptionDeleteClient(
-            LiClientRequestParams liClientRequestParams) throws LiRestResponseException {
-        liClientRequestParams.validate(Client.LI_SUBSCRIPTION_DELETE_CLIENT);
-        String id = ((LiClientRequestParams.LiDeleteSubscriptionParams) liClientRequestParams).getSubscriptionId();
-        LiClientRequestParams.LiGenericDeleteClientRequestParams liGenericDeleteClientRequestParams
-                = new LiClientRequestParams.LiGenericDeleteClientRequestParams(liClientRequestParams.getContext(),
-                CollectionsType.SUBSCRIPTION, id);
-        LiBaseDeleteClient liBaseDeleteClient = (LiBaseDeleteClient) getGenericQueryDeleteClient(
-                liGenericDeleteClientRequestParams);
-        return liBaseDeleteClient;
+    public static LiClient getSubscriptionDeleteClient(LiClientRequestParams params) throws LiRestResponseException {
+        params.validate(Client.LI_SUBSCRIPTION_DELETE_CLIENT);
+        String id = ((LiClientRequestParams.LiDeleteSubscriptionParams) params).getSubscriptionId();
+        LiClientRequestParams.LiGenericDeleteClientRequestParams outputParams
+                = new LiClientRequestParams.LiGenericDeleteClientRequestParams(params.getContext(), CollectionsType.SUBSCRIPTION, id);
+
+        return getGenericQueryDeleteClient(outputParams);
     }
 
     /**
-     * Updates an existing user. Create parameters with {@link LiClientRequestParams.LiUpdateUserParams}.
-     * Uses {@link LiCreateUpdateUserModel} to build the request body. The model is converted to a JsonObject, which
-     * is then used in the POST call.
      * <p>
-     * Added 1.1.0
+     * Updates an existing user. Create parameters with {@link LiClientRequestParams.LiUpdateUserParams}. Uses {@link LiCreateUpdateUserModel} to build the
+     * request body. The model is converted to a JsonObject, which is then used in the POST call.
+     * </p>
      *
-     * @param liClientRequestParams {@link LiClientRequestParams.LiUpdateUserParams} the Android context (required)
-     * @param liClientRequestParams the user's avatar image url
-     * @param liClientRequestParams the user's avatar image external url
-     * @param liClientRequestParams the user's avatar image internal url
-     * @param liClientRequestParams the user's avatar image id
-     * @param liClientRequestParams the user's biography
-     * @param liClientRequestParams the user's cover image
-     * @param liClientRequestParams the user's email
-     * @param liClientRequestParams the user's first name
-     * @param liClientRequestParams the user's last name
-     * @param liClientRequestParams the user's login
+     * @param params {@link LiClientRequestParams.LiUpdateUserParams}
+     *               the Android context (required)
+     *               the user's avatar image url
+     *               the user's avatar image external url
+     *               the user's avatar image internal url
+     *               the user's avatar image id
+     *               the user's biography
+     *               the user's cover image
+     *               the user's email
+     *               the user's first name
+     *               the user's last name
+     *               the user's login
      * @return {@link LiClient}
      * @throws LiRestResponseException
      */
-    public static LiClient getUpdateUserClient(LiClientRequestParams liClientRequestParams) throws LiRestResponseException {
-        liClientRequestParams.validate(Client.LI_UPDATE_USER_CLIENT);
+    public static LiClient getUpdateUserClient(LiClientRequestParams params) throws LiRestResponseException {
+        params.validate(Client.LI_UPDATE_USER_CLIENT);
 
-        final LiClientRequestParams.LiUpdateUserParams liUpdateUserParams = (LiClientRequestParams.LiUpdateUserParams) liClientRequestParams;
+        final LiClientRequestParams.LiUpdateUserParams liUpdateUserParams = (LiClientRequestParams.LiUpdateUserParams) params;
 
         final LiAvatar avatar = new LiAvatar();
 
@@ -1062,7 +957,7 @@ public class LiClientManager {
         final String login = liUpdateUserParams.getLogin();
         final String id = liUpdateUserParams.getId();
 
-        final LiBasePutClient liBasePutClient = new LiBasePutClient(liClientRequestParams.getContext(),
+        final LiBasePutClient liBasePutClient = new LiBasePutClient(params.getContext(),
                 String.format("/community/2.0/%s/users/%s", LiSDKManager.getInstance().getTenant(), id));
 
         final LiCreateUpdateUserModel liCreateUpdateUserModel = new LiCreateUpdateUserModel();
@@ -1080,27 +975,28 @@ public class LiClientManager {
     }
 
     /**
-     * This is generic Post client. Provide a path to a Community API v1 or v2 endpoint and a request body.
-     * Create parameters with {@link LiClientRequestParams.LiGenericPostClientRequestParams}.
+     * This is generic Post client. Provide a path to a Community API v1 or v2 endpoint and a request body. Create parameters with
+     * {@link LiClientRequestParams.LiGenericPostClientRequestParams}.
      *
-     * @param liClientRequestParams {@link LiClientRequestParams.LiGenericPostClientRequestParams} the Android context
-     * @param liClientRequestParams the path to a Community v1 or v2 endpoint
-     * @param liClientRequestParams the request body as a {@link JsonObject}
+     * @param params {@link LiClientRequestParams.LiGenericPostClientRequestParams}
+     *               the Android context
+     *               the path to a Community v1 or v2 endpoint
+     *               the request body as a {@link JsonObject}
      * @return {@link LiClient}
      * @throws LiRestResponseException {@link LiRestResponseException}
      */
-    public static LiClient getGenericPostClient(LiClientRequestParams liClientRequestParams) throws LiRestResponseException {
-        liClientRequestParams.validate(Client.LI_GENERIC_POST_CLIENT);
+    public static LiClient getGenericPostClient(LiClientRequestParams params) throws LiRestResponseException {
+        params.validate(Client.LI_GENERIC_POST_CLIENT);
 
-        final String path = ((LiClientRequestParams.LiGenericPostClientRequestParams) liClientRequestParams).getPath();
-        final JsonElement requestBody = ((LiClientRequestParams.LiGenericPostClientRequestParams) liClientRequestParams).getRequestBody();
+        final String path = ((LiClientRequestParams.LiGenericPostClientRequestParams) params).getPath();
+        final JsonElement requestBody = ((LiClientRequestParams.LiGenericPostClientRequestParams) params).getRequestBody();
 
-        final Map<String, String> additionalHeaders = ((LiClientRequestParams.LiGenericPostClientRequestParams) liClientRequestParams)
+        final Map<String, String> additionalHeaders = ((LiClientRequestParams.LiGenericPostClientRequestParams) params)
                 .getAdditionalHttpHeaders();
 
         final String requestPath = "/community/2.0/%s/" + path;
 
-        final LiBasePostClient liBasePostClient = new LiBasePostClient(liClientRequestParams.getContext(),
+        final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(),
                 String.format(requestPath, LiSDKManager.getInstance().getTenant()), additionalHeaders);
 
         final LiGenericPostModel genericPostModel = new LiGenericPostModel();
@@ -1113,15 +1009,14 @@ public class LiClientManager {
     /**
      * This is a beacon client which is used to send information to the community backend for analytics aka LSI
      *
-     * @param liClientRequestParams {@link LiClientRequestParams.LiBeaconPostClientRequestParams}
+     * @param params {@link LiClientRequestParams.LiBeaconPostClientRequestParams}
      */
-    public static LiClient getBeaconClient(LiClientRequestParams liClientRequestParams) throws LiRestResponseException {
-        liClientRequestParams.validate(Client.LI_BEACON_CLIENT);
-        LiClientRequestParams.LiBeaconPostClientRequestParams liBeaconPostClientRequestParams =
-                ((LiClientRequestParams.LiBeaconPostClientRequestParams) liClientRequestParams);
-        String targetType = liBeaconPostClientRequestParams.getTargetType();
-        String targetId = liBeaconPostClientRequestParams.getTargetId();
-        Context context = liBeaconPostClientRequestParams.getContext();
+    public static LiClient getBeaconClient(LiClientRequestParams params) throws LiRestResponseException {
+        params.validate(Client.LI_BEACON_CLIENT);
+        LiClientRequestParams.LiBeaconPostClientRequestParams beaconParams = ((LiClientRequestParams.LiBeaconPostClientRequestParams) params);
+        String targetType = beaconParams.getTargetType();
+        String targetId = beaconParams.getTargetId();
+        Context context = beaconParams.getContext();
         JsonObject requestBody = new JsonObject();
         if (!TextUtils.isEmpty(targetId) && !TextUtils.isEmpty(targetType)) {
             JsonObject targetJsonObject = new JsonObject();
@@ -1130,46 +1025,42 @@ public class LiClientManager {
             requestBody.add("target", targetJsonObject);
         }
         Map<String, String> additionalHeaders = new HashMap<>();
-        String visitOriginTime = LiSDKManager.getInstance().getFromSecuredPreferences(context,
-                LiCoreSDKConstants.LI_VISIT_ORIGIN_TIME_KEY);
+        String visitOriginTime = LiSDKManager.getInstance().getFromSecuredPreferences(context, LiCoreSDKConstants.LI_VISIT_ORIGIN_TIME_KEY);
         if (!TextUtils.isEmpty(visitOriginTime)) {
             additionalHeaders.put(LiRequestHeaderConstants.LI_REQUEST_VISIT_ORIGIN_TIME, visitOriginTime);
         }
-        String visitorLastIssuedTime = LiSDKManager.getInstance().getFromSecuredPreferences(context,
-                LiCoreSDKConstants.LI_VISIT_LAST_ISSUE_TIME_KEY);
+        String visitorLastIssuedTime = LiSDKManager.getInstance().getFromSecuredPreferences(context, LiCoreSDKConstants.LI_VISIT_LAST_ISSUE_TIME_KEY);
         if (!TextUtils.isEmpty(visitorLastIssuedTime)) {
             additionalHeaders.put(LiRequestHeaderConstants.LI_REQUEST_VISIT_LAST_ISSUE_TIME, visitorLastIssuedTime);
         }
 
-        LiClientRequestParams params = new LiClientRequestParams.LiGenericPostClientRequestParams(context, "beacon",
-                requestBody, additionalHeaders);
-        return LiClientManager.getGenericPostClient(params);
+        LiClientRequestParams outputParams = new LiClientRequestParams.LiGenericPostClientRequestParams(context, "beacon", requestBody, additionalHeaders);
+
+        return LiClientManager.getGenericPostClient(outputParams);
     }
 
     /**
-     * This is generic PUT client. Provide the path to a Community API v1 or v2 endpoint and a request body.
-     * Create parameters with {@link LiClientRequestParams.LiGenericPutClientRequestParams}.
+     * This is generic PUT client. Provide the path to a Community API v1 or v2 endpoint and a request body. Create parameters with
+     * {@link LiClientRequestParams.LiGenericPutClientRequestParams}.
      *
-     * @param liClientRequestParams {@link LiClientRequestParams.LiGenericPutClientRequestParams} the Android context
-     *                              (required)
-     * @param liClientRequestParams the path to a Community v1 or v2 endpoint (required)
-     * @param liClientRequestParams the request body as a {@link JsonObject} (required)
+     * @param params {@link LiClientRequestParams.LiGenericPutClientRequestParams}
+     *               the Android context  (required)
+     *               the path to a Community v1 or v2 endpoint (required)
+     *               the request body as a {@link JsonObject} (required)
      * @return {@link LiClient}
      * @throws LiRestResponseException {@link LiRestResponseException}
      */
-    public static LiClient getGenericPutClient(
-            LiClientRequestParams liClientRequestParams) throws LiRestResponseException {
-        liClientRequestParams.validate(Client.LI_GENERIC_PUT_CLIENT);
-        String path = ((LiClientRequestParams.LiGenericPutClientRequestParams) liClientRequestParams).getPath();
-        JsonObject requestBody
-                = ((LiClientRequestParams.LiGenericPutClientRequestParams) liClientRequestParams).getRequestBody();
+    public static LiClient getGenericPutClient(LiClientRequestParams params) throws LiRestResponseException {
+        params.validate(Client.LI_GENERIC_PUT_CLIENT);
+        String path = ((LiClientRequestParams.LiGenericPutClientRequestParams) params).getPath();
+        JsonObject requestBody = ((LiClientRequestParams.LiGenericPutClientRequestParams) params).getRequestBody();
         String requestPath = "/community/2.0/%s/" + path;
-        LiBasePutClient liBasePutClient = new LiBasePutClient(liClientRequestParams.getContext(),
-                String.format(requestPath,
-                        LiSDKManager.getInstance().getTenant()));
+        LiBasePutClient liBasePutClient = new LiBasePutClient(params.getContext(),
+                String.format(requestPath, LiSDKManager.getInstance().getTenant()));
         LiGenericPutModel genericPutModel = new LiGenericPutModel();
         genericPutModel.setData(requestBody);
         liBasePutClient.postModel = genericPutModel;
+
         return liBasePutClient;
     }
 
@@ -1177,79 +1068,69 @@ public class LiClientManager {
      * This is generic Get client. Provide a LiQL query. Create parameters with
      * {@link LiClientRequestParams.LiGenericLiqlClientRequestParams}.
      *
-     * @param liClientRequestParams {@link LiClientRequestParams.LiGenericLiqlClientRequestParams} the Android
-     *                              context (required)
-     * @param liClientRequestParams a custom LiQL query (required)
+     * @param params {@link LiClientRequestParams.LiGenericLiqlClientRequestParams}
+     *               the Android context (required)
+     *               a custom LiQL query (required)
      * @return LiClient {@link LiClient}
      * @throws LiRestResponseException {@link LiRestResponseException}
      */
-    public static LiClient getGenericLiqlGetClient(
-            LiClientRequestParams liClientRequestParams) throws LiRestResponseException {
-        liClientRequestParams.validate(Client.LI_GENERIC_LIQL_CLIENT);
-        String liQuery = ((LiClientRequestParams.LiGenericLiqlClientRequestParams) liClientRequestParams).getLiQuery();
-        return new LiBaseGetClient(liClientRequestParams.getContext(), liQuery, null, LiQueryConstant.LI_GENERIC_TYPE,
-                null);
+    public static LiClient getGenericLiqlGetClient(LiClientRequestParams params) throws LiRestResponseException {
+        params.validate(Client.LI_GENERIC_LIQL_CLIENT);
+        String liQuery = ((LiClientRequestParams.LiGenericLiqlClientRequestParams) params).getLiQuery();
+
+        return new LiBaseGetClient(params.getContext(), liQuery, null, LiQueryConstant.LI_GENERIC_TYPE, null);
     }
 
     /**
      * This is generic Get client. Provide a LiQL query. Create parameters with
      * {@link LiClientRequestParams.LiGenericLiqlClientRequestParams}.
      *
-     * @param liClientRequestParams {@link LiClientRequestParams.LiGenericLiqlClientRequestParams} the Android
-     *                              context (required)
-     * @param liClientRequestParams a custom LiQL query (required)
+     * @param params {@link LiClientRequestParams.LiGenericLiqlClientRequestParams}
+     *               the Android context (required)
+     *               a custom LiQL query (required)
      * @return LiClient {@link LiClient}
      * @throws LiRestResponseException {@link LiRestResponseException}
      */
-    public static LiClient getGenericNoLiqlGetClient(
-            LiClientRequestParams liClientRequestParams) throws LiRestResponseException {
-        liClientRequestParams.validate(Client.LI_GENERIC_LIQL_CLIENT);
-        String pathParam
-                = ((LiClientRequestParams.LiGenericNoLiqlClientRequestParams) liClientRequestParams).getPathParam();
-        String queryParams
-                = ((LiClientRequestParams.LiGenericNoLiqlClientRequestParams) liClientRequestParams).getQueryParams();
-        return new LiBaseGetClient(liClientRequestParams.getContext(), queryParams, null,
-                LiQueryConstant.LI_GENERIC_TYPE, null, pathParam);
+    public static LiClient getGenericNoLiqlGetClient(LiClientRequestParams params) throws LiRestResponseException {
+        params.validate(Client.LI_GENERIC_LIQL_CLIENT);
+        String pathParam = ((LiClientRequestParams.LiGenericNoLiqlClientRequestParams) params).getPathParam();
+        String queryParams = ((LiClientRequestParams.LiGenericNoLiqlClientRequestParams) params).getQueryParams();
+
+        return new LiBaseGetClient(params.getContext(), queryParams, null, LiQueryConstant.LI_GENERIC_TYPE, null, pathParam);
     }
 
 
     /**
-     * Creates custom WHERE clause, ORDER BY, and/or LIMIT parameters to a LIQL queries used by a Lithium API provider.
-     * Create parameters with {@link LiClientRequestParams.LiGenericQueryParamsClientRequestParams}.
+     * Creates custom WHERE clause, ORDER BY, and/or LIMIT parameters to a LIQL queries used by a Lithium API provider. Create parameters with
+     * {@link LiClientRequestParams.LiGenericQueryParamsClientRequestParams}.
      *
-     * @param liClientRequestParams {@link LiClientRequestParams.LiGenericQueryParamsClientRequestParams} the Android
-     *                              context
+     * @param params {@link LiClientRequestParams.LiGenericQueryParamsClientRequestParams} the Android context
      * @return LiClient {@link LiClient}
      */
-    public static LiClient getGenericQueryParamsGetClient(LiClientRequestParams liClientRequestParams) {
-        liClientRequestParams.validate(Client.LI_GENERIC_QUERY_PARAMS_CLIENT);
-        LiQueryRequestParams liQueryRequestParams
-                = ((LiClientRequestParams.LiGenericQueryParamsClientRequestParams) liClientRequestParams)
-                .getLiQueryRequestParams();
-        return new LiBaseGetClient(liClientRequestParams.getContext(),
-                LiClientConfig.getBaseQuery(liQueryRequestParams.getClient()),
-                LiClientConfig.getType(liQueryRequestParams.getClient()),
-                LiClientConfig.getResponseClass(liQueryRequestParams.getClient()), liQueryRequestParams);
+    public static LiClient getGenericQueryParamsGetClient(LiClientRequestParams params) {
+        params.validate(Client.LI_GENERIC_QUERY_PARAMS_CLIENT);
+        LiQueryRequestParams liQueryRequestParams = ((LiClientRequestParams.LiGenericQueryParamsClientRequestParams) params).getLiQueryRequestParams();
+
+        return new LiBaseGetClient(params.getContext(), LiClientConfig.getBaseQuery(liQueryRequestParams.getClient()),
+                LiClientConfig.getType(liQueryRequestParams.getClient()), LiClientConfig.getResponseClass(liQueryRequestParams.getClient()),
+                liQueryRequestParams);
     }
 
     /**
      * This is a generic DELETE client.
      *
-     * @param liClientRequestParams {@link LiClientRequestParams.LiGenericDeleteClientRequestParams}
+     * @param params {@link LiClientRequestParams.LiGenericDeleteClientRequestParams}
      * @return LiClient {@link LiClient}
      */
-    public static LiClient getGenericQueryDeleteClient(
-            LiClientRequestParams liClientRequestParams) throws LiRestResponseException {
-        liClientRequestParams.validate(Client.LI_GENERIC_DELETE_QUERY_PARAMS_CLIENT);
-        LiClientRequestParams.LiGenericDeleteClientRequestParams clientRequestParams
-                = (LiClientRequestParams.LiGenericDeleteClientRequestParams) liClientRequestParams;
+    public static LiClient getGenericQueryDeleteClient(LiClientRequestParams params) throws LiRestResponseException {
+        params.validate(Client.LI_GENERIC_DELETE_QUERY_PARAMS_CLIENT);
+        LiClientRequestParams.LiGenericDeleteClientRequestParams clientRequestParams = (LiClientRequestParams.LiGenericDeleteClientRequestParams) params;
         Map<String, String> queryRequestParams = clientRequestParams.getLiQueryRequestParams();
         String id = clientRequestParams.getId();
         String extraPathAfterId = clientRequestParams.getSubResourcePath();
         CollectionsType collectionsType = clientRequestParams.getCollectionsType();
         StringBuilder path = new StringBuilder();
-        path = path.append(String.format("/community/2.0/%s/%s/%s", LiSDKManager.getInstance().getTenant(),
-                collectionsType.getValue(), id));
+        path = path.append(String.format("/community/2.0/%s/%s/%s", LiSDKManager.getInstance().getTenant(), collectionsType.getValue(), id));
         if (extraPathAfterId != null) {
             path = path.append(extraPathAfterId);
         }
@@ -1262,41 +1143,34 @@ public class LiClientManager {
                 }
             }
         }
-        return new LiBaseDeleteClient(liClientRequestParams.getContext(), path.toString());
+
+        return new LiBaseDeleteClient(params.getContext(), path.toString());
     }
 
     /**
-     * Deletes the specified message. Create parameters with
-     * {@link lithium.community.android.sdk.model.request.LiClientRequestParams.LiMessageDeleteClientRequestParams}.
-     * Optionally pass the 'includeReplies' parameters as 'true' to delete replies or comments associated with the
-     * message.
+     * Deletes the specified message. Create parameters with {@link LiClientRequestParams.LiMessageDeleteClientRequestParams}. Optionally pass the
+     * 'includeReplies' parameters as 'true' to delete replies or comments associated with the message.
      *
-     * @param liClientRequestParams {@link LiClientRequestParams.LiMessageDeleteClientRequestParams} the Android context
-     * @param liClientRequestParams the ID of the message to delete
-     * @param liClientRequestParams whether or not to delete replies/comments to the message
+     * @param params {@link LiClientRequestParams.LiMessageDeleteClientRequestParams}
+     *               the Android context
+     *               the ID of the message to delete
+     *               whether or not to delete replies/comments to the message
      * @return LiClient {@link LiClient}
      * @throws LiRestResponseException {@link LiRestResponseException}
      */
-    public static LiClient getMessageDeleteClient(
-            LiClientRequestParams liClientRequestParams) throws LiRestResponseException {
-        liClientRequestParams.validate(Client.LI_MESSAGE_DELETE_CLIENT);
-        String messageId
-                = ((LiClientRequestParams.LiMessageDeleteClientRequestParams) liClientRequestParams).getMessageId();
-        boolean includeReplies
-                = ((LiClientRequestParams.LiMessageDeleteClientRequestParams) liClientRequestParams).isIncludeReplies();
-        LiClientRequestParams.LiGenericDeleteClientRequestParams liGenericDeleteClientRequestParams;
+    public static LiClient getMessageDeleteClient(LiClientRequestParams params) throws LiRestResponseException {
+        params.validate(Client.LI_MESSAGE_DELETE_CLIENT);
+        String messageId = ((LiClientRequestParams.LiMessageDeleteClientRequestParams) params).getMessageId();
+        boolean includeReplies = ((LiClientRequestParams.LiMessageDeleteClientRequestParams) params).isIncludeReplies();
+        LiClientRequestParams.LiGenericDeleteClientRequestParams deleteParams;
         if (includeReplies) {
             Map<String, String> requestParams = new HashMap<>();
             requestParams.put("delete_message.include_replies", "true");
-            liGenericDeleteClientRequestParams = new LiClientRequestParams.LiGenericDeleteClientRequestParams(
-                    liClientRequestParams.getContext(), CollectionsType.MESSAGE, messageId, requestParams);
+            deleteParams = new LiClientRequestParams.LiGenericDeleteClientRequestParams(params.getContext(), CollectionsType.MESSAGE, messageId, requestParams);
         } else {
-            liGenericDeleteClientRequestParams = new LiClientRequestParams.LiGenericDeleteClientRequestParams(
-                    liClientRequestParams.getContext(), CollectionsType.MESSAGE, messageId);
+            deleteParams = new LiClientRequestParams.LiGenericDeleteClientRequestParams(params.getContext(), CollectionsType.MESSAGE, messageId);
         }
-        LiBaseDeleteClient liBaseDeleteClient = (LiBaseDeleteClient) getGenericQueryDeleteClient(
-                liGenericDeleteClientRequestParams);
-        return liBaseDeleteClient;
+        return getGenericQueryDeleteClient(deleteParams);
     }
 
 

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiClientManager.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiClientManager.java
@@ -360,7 +360,7 @@ public class LiClientManager {
         params.validate(Client.LI_KUDO_CLIENT);
         String messageId = ((LiClientRequestParams.LiKudoClientRequestParams) params).getMessageId();
         final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(), String.format("/community/2.0/%s/messages/%s/kudos",
-                LiSDKManager.getInstance().getTenant(), messageId));
+                LiSDKManager.getInstance().getTenantId(), messageId));
 
         LiPostKudoModel liPostKudoModel = new LiPostKudoModel();
         LiMessage liMessage = new LiMessage();
@@ -403,7 +403,7 @@ public class LiClientManager {
         params.validate(Client.LI_ACCEPT_SOLUTION_CLIENT);
         Long messageId = ((LiClientRequestParams.LiAcceptSolutionClientRequestParams) params).getMessageId();
         LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(),
-                String.format("/community/2.0/%s/solutions_data", LiSDKManager.getInstance().getTenant()));
+                String.format("/community/2.0/%s/solutions_data", LiSDKManager.getInstance().getTenantId()));
         LiAcceptSolutionModel liAcceptSolutionModel = new LiAcceptSolutionModel();
         liAcceptSolutionModel.setType(LiQueryConstant.LI_ACCEPT_SOLUTION_TYPE);
         liAcceptSolutionModel.setMessageid(String.valueOf(messageId));
@@ -433,7 +433,7 @@ public class LiClientManager {
         final String imageName = ((LiClientRequestParams.LiCreateMessageClientRequestParams) params).getImageName();
 
         final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(),
-                String.format("/community/2.0/%s/messages", LiSDKManager.getInstance().getTenant()));
+                String.format("/community/2.0/%s/messages", LiSDKManager.getInstance().getTenantId()));
 
         LiPostMessageModel liPostMessageModel = new LiPostMessageModel();
         LiBoard liBoard = new LiBoard();
@@ -471,7 +471,7 @@ public class LiClientManager {
         final String messageId = ((LiClientRequestParams.LiUpdateMessageClientRequestParams) params).getMessageId();
 
         final LiBasePutClient liBasePutClient = new LiBasePutClient(params.getContext(),
-                String.format("/community/2.0/%s/messages/%s", LiSDKManager.getInstance().getTenant(), messageId));
+                String.format("/community/2.0/%s/messages/%s", LiSDKManager.getInstance().getTenantId(), messageId));
         LiPostMessageModel liPostMessageModel = new LiPostMessageModel();
         liPostMessageModel.setType(LI_POST_QUESTION_TYPE);
         liPostMessageModel.setBody(body);
@@ -519,7 +519,7 @@ public class LiClientManager {
         final String imageId = ((LiClientRequestParams.LiCreateReplyClientRequestParams) params).getImageId();
         final String imageName = ((LiClientRequestParams.LiCreateReplyClientRequestParams) params).getImageName();
         final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(),
-                String.format("/community/2.0/%s/messages", LiSDKManager.getInstance().getTenant()));
+                String.format("/community/2.0/%s/messages", LiSDKManager.getInstance().getTenantId()));
 
         final LiReplyMessageModel liReplyMessage = new LiReplyMessageModel();
         LiMessage parent = new LiMessage();
@@ -561,7 +561,7 @@ public class LiClientManager {
         final String imageName = ((LiClientRequestParams.LiUploadImageClientRequestParams) params).getImageName();
         final String path = ((LiClientRequestParams.LiUploadImageClientRequestParams) params).getPath();
         final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(),
-                String.format("/community/2.0/%s/images", LiSDKManager.getInstance().getTenant()), path, imageName);
+                String.format("/community/2.0/%s/images", LiSDKManager.getInstance().getTenantId()), path, imageName);
 
         LiUploadImageModel uploadImageModel = new LiUploadImageModel();
         uploadImageModel.setType(LiQueryConstant.LI_IMAGE_TYPE);
@@ -593,7 +593,7 @@ public class LiClientManager {
         final String userId = ((LiClientRequestParams.LiReportAbuseClientRequestParams) params).getUserId();
         final String body = ((LiClientRequestParams.LiReportAbuseClientRequestParams) params).getBody();
         final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(),
-                String.format("/community/2.0/%s/abuse_reports", LiSDKManager.getInstance().getTenant()));
+                String.format("/community/2.0/%s/abuse_reports", LiSDKManager.getInstance().getTenantId()));
 
         LiMarkAbuseModel liMarkAbuseModel = new LiMarkAbuseModel();
         liMarkAbuseModel.setType(LiQueryConstant.LI_MARK_ABUSE_TYPE);
@@ -630,7 +630,7 @@ public class LiClientManager {
         final String pushNotificationProvider = ((LiClientRequestParams.LiDeviceIdFetchClientRequestParams) params)
                 .getPushNotificationProvider();
         final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(),
-                String.format("/community/2.0/%s/user_device_data", LiSDKManager.getInstance().getTenant()));
+                String.format("/community/2.0/%s/user_device_data", LiSDKManager.getInstance().getTenantId()));
 
         final LiUserDeviceDataModel liUserDeviceDataModel = new LiUserDeviceDataModel();
         liUserDeviceDataModel.setType(LiQueryConstant.LI_USER_DEVICE_ID_FETCH_TYPE);
@@ -658,7 +658,7 @@ public class LiClientManager {
         String deviceId = ((LiClientRequestParams.LiDeviceIdUpdateClientRequestParams) params).getDeviceId();
         String id = ((LiClientRequestParams.LiDeviceIdUpdateClientRequestParams) params).getDeviceId();
         String path = "/community/2.0/%s/user_device_data/" + id;
-        LiBasePutClient liBasePostClient = new LiBasePutClient(params.getContext(), String.format(path, LiSDKManager.getInstance().getTenant()));
+        LiBasePutClient liBasePostClient = new LiBasePutClient(params.getContext(), String.format(path, LiSDKManager.getInstance().getTenantId()));
         LiUserDeviceIdUpdateModel liUserDeviceIdUpdateModel = new LiUserDeviceIdUpdateModel();
         liUserDeviceIdUpdateModel.setType(LiQueryConstant.LI_USER_DEVICE_ID_FETCH_TYPE);
         liUserDeviceIdUpdateModel.setDeviceId(deviceId);
@@ -711,7 +711,7 @@ public class LiClientManager {
         final String password = ((LiClientRequestParams.LiCreateUserParams) params).getPassword();
 
         final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(),
-                String.format("/community/2.0/%s/users", LiSDKManager.getInstance().getTenant()));
+                String.format("/community/2.0/%s/users", LiSDKManager.getInstance().getTenantId()));
 
         final LiCreateUpdateUserModel liCreateUpdateUserModel = new LiCreateUpdateUserModel();
         liCreateUpdateUserModel.setType(LI_USER_DETAILS_CLIENT_TYPE);
@@ -748,7 +748,7 @@ public class LiClientManager {
         final boolean markUnread = ((LiClientRequestParams.LiMarkMessageParams) params).isMarkUnread();
 
         final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(),
-                String.format("/community/2.0/%s/messages_read", LiSDKManager.getInstance().getTenant()));
+                String.format("/community/2.0/%s/messages_read", LiSDKManager.getInstance().getTenantId()));
 
         final LiMarkMessageModel liMarkMessageModel = new LiMarkMessageModel();
         liMarkMessageModel.setType(LI_MARK_MESSAGE_CLIENT_TYPE);
@@ -781,7 +781,7 @@ public class LiClientManager {
         final boolean markUnread = ((LiClientRequestParams.LiMarkMessagesParams) params).isMarkUnread();
 
         final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(),
-                String.format("/community/2.0/%s/messages_read", LiSDKManager.getInstance().getTenant()));
+                String.format("/community/2.0/%s/messages_read", LiSDKManager.getInstance().getTenantId()));
 
         final LiMarkMessagesModel liMarkMessagesModel = new LiMarkMessagesModel();
         liMarkMessagesModel.setType(LI_MARK_MESSAGE_CLIENT_TYPE);
@@ -814,7 +814,7 @@ public class LiClientManager {
         final boolean markUnread = ((LiClientRequestParams.LiMarkTopicParams) params).isMarkUnread();
 
         final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(),
-                String.format("/community/2.0/%s/messages_read", LiSDKManager.getInstance().getTenant()));
+                String.format("/community/2.0/%s/messages_read", LiSDKManager.getInstance().getTenantId()));
 
         LiMarkTopicModel liMarkTopicModel = new LiMarkTopicModel();
         liMarkTopicModel.setType(LI_MARK_MESSAGE_CLIENT_TYPE);
@@ -871,7 +871,7 @@ public class LiClientManager {
         target.setType(targetType);
         target.setId(targetID);
         LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(),
-                String.format("/community/2.0/%s/subscriptions", LiSDKManager.getInstance().getTenant()));
+                String.format("/community/2.0/%s/subscriptions", LiSDKManager.getInstance().getTenantId()));
         LiSubscriptionPostModel liSubscriptionPostModel = new LiSubscriptionPostModel();
         liSubscriptionPostModel.setType(LI_SUBSCRIPTIONS_CLIENT_TYPE);
         liSubscriptionPostModel.setTarget(target);
@@ -958,7 +958,7 @@ public class LiClientManager {
         final String id = liUpdateUserParams.getId();
 
         final LiBasePutClient liBasePutClient = new LiBasePutClient(params.getContext(),
-                String.format("/community/2.0/%s/users/%s", LiSDKManager.getInstance().getTenant(), id));
+                String.format("/community/2.0/%s/users/%s", LiSDKManager.getInstance().getTenantId(), id));
 
         final LiCreateUpdateUserModel liCreateUpdateUserModel = new LiCreateUpdateUserModel();
         liCreateUpdateUserModel.setType(LI_USER_DETAILS_CLIENT_TYPE);
@@ -997,7 +997,7 @@ public class LiClientManager {
         final String requestPath = "/community/2.0/%s/" + path;
 
         final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(),
-                String.format(requestPath, LiSDKManager.getInstance().getTenant()), additionalHeaders);
+                String.format(requestPath, LiSDKManager.getInstance().getTenantId()), additionalHeaders);
 
         final LiGenericPostModel genericPostModel = new LiGenericPostModel();
         genericPostModel.setData(requestBody);
@@ -1056,7 +1056,7 @@ public class LiClientManager {
         JsonObject requestBody = ((LiClientRequestParams.LiGenericPutClientRequestParams) params).getRequestBody();
         String requestPath = "/community/2.0/%s/" + path;
         LiBasePutClient liBasePutClient = new LiBasePutClient(params.getContext(),
-                String.format(requestPath, LiSDKManager.getInstance().getTenant()));
+                String.format(requestPath, LiSDKManager.getInstance().getTenantId()));
         LiGenericPutModel genericPutModel = new LiGenericPutModel();
         genericPutModel.setData(requestBody);
         liBasePutClient.postModel = genericPutModel;
@@ -1130,7 +1130,7 @@ public class LiClientManager {
         String extraPathAfterId = clientRequestParams.getSubResourcePath();
         CollectionsType collectionsType = clientRequestParams.getCollectionsType();
         StringBuilder path = new StringBuilder();
-        path = path.append(String.format("/community/2.0/%s/%s/%s", LiSDKManager.getInstance().getTenant(), collectionsType.getValue(), id));
+        path = path.append(String.format("/community/2.0/%s/%s/%s", LiSDKManager.getInstance().getTenantId(), collectionsType.getValue(), id));
         if (extraPathAfterId != null) {
             path = path.append(extraPathAfterId);
         }

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiSDKManager.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiSDKManager.java
@@ -40,7 +40,6 @@ import lithium.community.android.sdk.exception.LiRestResponseException;
 import lithium.community.android.sdk.model.request.LiClientRequestParams;
 import lithium.community.android.sdk.model.response.LiAppSdkSettings;
 import lithium.community.android.sdk.model.response.LiUser;
-import lithium.community.android.sdk.queryutil.LiDefaultQueryHelper;
 import lithium.community.android.sdk.rest.LiAsyncRequestCallback;
 import lithium.community.android.sdk.rest.LiBaseRestRequest;
 import lithium.community.android.sdk.rest.LiGetClientResponse;
@@ -54,12 +53,14 @@ import static lithium.community.android.sdk.utils.LiCoreSDKConstants.LI_DEFAULT_
 import static lithium.community.android.sdk.utils.LiCoreSDKConstants.LI_VISITOR_ID;
 
 /**
+ * <p>
  * Interface to Lithium Community Android SDK. Provides the entry point into
  * the Community REST API v2 using OAuth2.
+ * </p>
+ *
+ * @author adityasharat
  */
 public final class LiSDKManager extends LiAuthManager {
-
-    private static final String COMPONENT_NAME = LiSDKManager.class.getName();
 
     private static AtomicBoolean isInitialized = new AtomicBoolean(false);
     private static LiSDKManager instance;
@@ -73,7 +74,7 @@ public final class LiSDKManager extends LiAuthManager {
      * @param context     The Android context.
      * @param credentials The credentials to be used to authenticate the SDK.
      */
-    private LiSDKManager(@NonNull Context context, @NonNull LiAppCredentials credentials) {
+    private LiSDKManager(@NonNull Context context, @NonNull LiAppCredentials credentials) throws LiInitializationException {
         super(context, credentials);
     }
 
@@ -85,17 +86,9 @@ public final class LiSDKManager extends LiAuthManager {
      * @param credentials The {@link LiAppCredentials} for authenticating the SDK.
      */
     public static synchronized void initialize(@NonNull final Context context, @NonNull final LiAppCredentials credentials) throws LiInitializationException {
-
         LiCoreSDKUtils.checkNotNull(context, MessageConstants.wasNull("context"));
         LiCoreSDKUtils.checkNotNull(credentials, MessageConstants.wasNull("credentials"));
-
         if (isInitialized.compareAndSet(false, true)) {
-            if (LiDefaultQueryHelper.initHelper(context) == null) {
-                throw new LiInitializationException(COMPONENT_NAME);
-            }
-            if (LiSecuredPrefManager.init(context) == null) {
-                throw new LiInitializationException(COMPONENT_NAME);
-            }
             instance = new LiSDKManager(context, credentials);
         }
         updatePreferences(context);
@@ -110,23 +103,16 @@ public final class LiSDKManager extends LiAuthManager {
      * @throws URISyntaxException Does not throw a URISyntaxException but still here for legacy support.
      * @deprecated Use {@link #initialize(Context, LiAppCredentials)} instead.
      */
+    @Deprecated
     @Nullable
     public static synchronized LiSDKManager init(@NonNull final Context context, @NonNull final LiAppCredentials credentials) throws URISyntaxException {
-
-        LiCoreSDKUtils.checkNotNull(context, MessageConstants.wasNull("context"));
-        LiCoreSDKUtils.checkNotNull(credentials, MessageConstants.wasNull("credentials"));
-
-        if (isInitialized.compareAndSet(false, true)) {
-            if (LiDefaultQueryHelper.initHelper(context) == null) {
-                return null;
-            }
-            if (LiSecuredPrefManager.init(context) == null) {
-                return null;
-            }
-            instance = new LiSDKManager(context, credentials);
+        try {
+            initialize(context, credentials);
+        } catch (LiInitializationException e) {
+            e.printStackTrace();
         }
-        updatePreferences(context);
-        return instance;
+
+        return getInstance();
     }
 
     /**
@@ -145,6 +131,7 @@ public final class LiSDKManager extends LiAuthManager {
      * @return true or false depending on whether the SDK is initialized
      * @deprecated Use {@link #isInitialized()} instead.
      */
+    @Deprecated
     public static boolean isEnvironmentInitialized() {
         return isInitialized.get() && instance != null;
     }

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiSDKManager.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiSDKManager.java
@@ -141,7 +141,6 @@ public final class LiSDKManager extends LiAuthManager {
      *
      * @return if the SDK initialized then the current instance of {@link LiSDKManager} is return, else {@code null} is returned.
      */
-    @Nullable
     public static LiSDKManager getInstance() {
         return instance;
     }

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiSecuredPrefManager.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiSecuredPrefManager.java
@@ -148,7 +148,7 @@ class LiSecuredPrefManager {
     @Nullable
     public String getString(@NonNull Context context, @NonNull String key) {
         LiCoreSDKUtils.checkNotNull(context, MessageConstants.wasNull("context"));
-        LiCoreSDKUtils.checkNullOrNotEmpty(key, MessageConstants.wasNull("key"));
+        LiCoreSDKUtils.checkNotNullAndNotEmpty(key, MessageConstants.wasNull("key"));
         SharedPreferences preferences = getSecuredPreferences(context);
         String value = null;
         try {
@@ -173,8 +173,8 @@ class LiSecuredPrefManager {
      */
     public void putString(@NonNull Context context, @NonNull String key, @NonNull String value) {
         LiCoreSDKUtils.checkNotNull(context, MessageConstants.wasNull("context"));
-        LiCoreSDKUtils.checkNullOrNotEmpty(key, MessageConstants.wasNull("key"));
-        LiCoreSDKUtils.checkNullOrNotEmpty(key, MessageConstants.wasNull("value"));
+        LiCoreSDKUtils.checkNotNullAndNotEmpty(key, MessageConstants.wasNull("key"));
+        LiCoreSDKUtils.checkNotNullAndNotEmpty(key, MessageConstants.wasNull("value"));
         try {
             String encryptedKey = encrypt(key);
             String encryptedValue = encrypt(value);
@@ -193,7 +193,7 @@ class LiSecuredPrefManager {
      */
     public void remove(@NonNull Context context, @NonNull String key) {
         LiCoreSDKUtils.checkNotNull(context, MessageConstants.wasNull("context"));
-        LiCoreSDKUtils.checkNullOrNotEmpty(key, MessageConstants.wasNull("key"));
+        LiCoreSDKUtils.checkNotNullAndNotEmpty(key, MessageConstants.wasNull("key"));
         try {
             String encryptedString = encrypt(key);
             getSecuredPreferences(context).edit().remove(encryptedString).apply();

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiSecuredPrefManager.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiSecuredPrefManager.java
@@ -197,7 +197,7 @@ class LiSecuredPrefManager {
         try {
             String encryptedString = encrypt(key);
             getSecuredPreferences(context).edit().remove(encryptedString).apply();
-        } catch (Exception e) {
+        } catch (NoSuchAlgorithmException | InvalidKeyException | NoSuchPaddingException | BadPaddingException | IllegalBlockSizeException e) {
             e.printStackTrace();
             getSecuredPreferences(context).edit().remove(key).apply();
         }
@@ -214,23 +214,23 @@ class LiSecuredPrefManager {
     }
 
     @NonNull
-    private String encrypt(@NonNull String string) throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeyException,
+    private String encrypt(@NonNull String input) throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeyException,
             BadPaddingException, IllegalBlockSizeException {
         @SuppressLint("GetInstance")
         Cipher cipher = Cipher.getInstance(ENCRYPTION_ALGORITHM);
         cipher.init(Cipher.ENCRYPT_MODE, key);
-        byte[] bytes = string.getBytes();
+        byte[] bytes = input.getBytes();
         byte[] encrypted = cipher.doFinal(bytes);
         return encode(encrypted);
     }
 
     @NonNull
-    private String decrypt(@NonNull String string) throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeyException,
+    private String decrypt(@NonNull String input) throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeyException,
             BadPaddingException, IllegalBlockSizeException {
         @SuppressLint("GetInstance")
         Cipher cipher = Cipher.getInstance(ENCRYPTION_ALGORITHM);
         cipher.init(Cipher.DECRYPT_MODE, key);
-        byte[] decoded = decode(string);
+        byte[] decoded = decode(input);
         byte[] decrypted = cipher.doFinal(decoded);
         return new String(decrypted);
     }

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiSecuredPrefManager.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiSecuredPrefManager.java
@@ -203,6 +203,16 @@ class LiSecuredPrefManager {
         }
     }
 
+    /**
+     * Clears all saved preferences.
+     *
+     * @param context An Android Context.
+     */
+    public void clear(@NonNull Context context) {
+        LiCoreSDKUtils.checkNotNull(context, MessageConstants.wasNull("context"));
+        getSecuredPreferences(context).edit().clear().apply();
+    }
+
     @NonNull
     private String encrypt(@NonNull String string) throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeyException,
             BadPaddingException, IllegalBlockSizeException {

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiSecuredPrefManager.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiSecuredPrefManager.java
@@ -113,7 +113,6 @@ class LiSecuredPrefManager {
      *
      * @return Instance of the Secured Preference Manager.
      */
-    @Nullable
     public static LiSecuredPrefManager getInstance() {
         return instance;
     }

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiSecuredPrefManager.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiSecuredPrefManager.java
@@ -24,7 +24,6 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.util.Base64;
 
-import java.io.UnsupportedEncodingException;
 import java.security.InvalidKeyException;
 import java.security.Key;
 import java.security.MessageDigest;
@@ -68,7 +67,7 @@ class LiSecuredPrefManager {
      * @param secret The secret encryption key.
      * @throws NoSuchAlgorithmException If the device does not support SHA-1 encryption.
      */
-    private LiSecuredPrefManager(@NonNull String secret) throws NoSuchAlgorithmException, UnsupportedEncodingException {
+    private LiSecuredPrefManager(@NonNull String secret) throws NoSuchAlgorithmException {
         LiCoreSDKUtils.checkNotNull(secret, MessageConstants.wasNull("secret encryption key"));
         MessageDigest sha = MessageDigest.getInstance("SHA1");
         key = new SecretKeySpec(Arrays.copyOf(sha.digest(secret.getBytes()), ENCRYPTION_LENGTH), "AES");
@@ -83,7 +82,7 @@ class LiSecuredPrefManager {
         if (isInitialized.compareAndSet(false, true)) {
             try {
                 instance = new LiSecuredPrefManager(secret);
-            } catch (NoSuchAlgorithmException | UnsupportedEncodingException e) {
+            } catch (NoSuchAlgorithmException e) {
                 e.printStackTrace();
                 throw new LiInitializationException(LiSecuredPrefManager.class.getSimpleName(), e);
             }
@@ -120,7 +119,7 @@ class LiSecuredPrefManager {
     }
 
     @NonNull
-    private static String encode(@NonNull byte[] input) throws UnsupportedEncodingException {
+    private static String encode(@NonNull byte[] input) {
         return Base64.encodeToString(input, Base64.DEFAULT);
     }
 
@@ -159,8 +158,7 @@ class LiSecuredPrefManager {
             if (encryptedValue != null) {
                 value = decrypt(encryptedValue);
             }
-        } catch (NoSuchAlgorithmException | InvalidKeyException | NoSuchPaddingException
-                | BadPaddingException | UnsupportedEncodingException | IllegalBlockSizeException e) {
+        } catch (NoSuchAlgorithmException | InvalidKeyException | NoSuchPaddingException | BadPaddingException | IllegalBlockSizeException e) {
             e.printStackTrace();
             value = preferences.getString(key, null);
         }
@@ -182,8 +180,7 @@ class LiSecuredPrefManager {
             String encryptedKey = encrypt(key);
             String encryptedValue = encrypt(value);
             getSecuredPreferences(context).edit().putString(encryptedKey, encryptedValue).apply();
-        } catch (NoSuchAlgorithmException | InvalidKeyException | NoSuchPaddingException
-                | BadPaddingException | UnsupportedEncodingException | IllegalBlockSizeException e) {
+        } catch (NoSuchAlgorithmException | InvalidKeyException | NoSuchPaddingException | BadPaddingException | IllegalBlockSizeException e) {
             e.printStackTrace();
             getSecuredPreferences(context).edit().putString(key, value).apply();
         }
@@ -209,7 +206,7 @@ class LiSecuredPrefManager {
 
     @NonNull
     private String encrypt(@NonNull String string) throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeyException,
-            UnsupportedEncodingException, BadPaddingException, IllegalBlockSizeException {
+            BadPaddingException, IllegalBlockSizeException {
         @SuppressLint("GetInstance")
         Cipher cipher = Cipher.getInstance(ENCRYPTION_ALGORITHM);
         cipher.init(Cipher.ENCRYPT_MODE, key);
@@ -220,7 +217,7 @@ class LiSecuredPrefManager {
 
     @NonNull
     private String decrypt(@NonNull String string) throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeyException,
-            BadPaddingException, IllegalBlockSizeException, UnsupportedEncodingException {
+            BadPaddingException, IllegalBlockSizeException {
         @SuppressLint("GetInstance")
         Cipher cipher = Cipher.getInstance(ENCRYPTION_ALGORITHM);
         cipher.init(Cipher.DECRYPT_MODE, key);

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiSecuredPrefManager.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiSecuredPrefManager.java
@@ -16,138 +16,216 @@
 
 package lithium.community.android.sdk.manager;
 
+import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.provider.Settings;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.util.Base64;
-import android.util.Log;
 
+import java.io.UnsupportedEncodingException;
+import java.security.InvalidKeyException;
 import java.security.Key;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import javax.crypto.BadPaddingException;
 import javax.crypto.Cipher;
+import javax.crypto.IllegalBlockSizeException;
+import javax.crypto.NoSuchPaddingException;
 import javax.crypto.spec.SecretKeySpec;
 
+import lithium.community.android.sdk.exception.LiInitializationException;
 import lithium.community.android.sdk.utils.LiCoreSDKConstants;
-
-import static lithium.community.android.sdk.utils.LiCoreSDKConstants.LI_LOG_TAG;
+import lithium.community.android.sdk.utils.LiCoreSDKUtils;
+import lithium.community.android.sdk.utils.MessageConstants;
 
 /**
- * Created by Lithium Technologies Inc on 5/29/17.
+ * <p>
+ * Lia Secured Preference Manager is used internally by the SDK to
+ * securely manage preferences which are used by the SDK.
+ * </p>
+ *
+ * @author adityasharat
  */
 class LiSecuredPrefManager {
 
-    private static final String ENCRYPTION_ALGORITHM = "AES";
+    private static final String ENCRYPTION_ALGORITHM = "AES/ECB/PKCS5Padding";
     private static final int ENCRYPTION_LENGTH = 16;
 
     private static AtomicBoolean isInitialized = new AtomicBoolean(false);
     private static LiSecuredPrefManager instance;
 
-    private MessageDigest sha;
-    private Key aesKey;
-    private byte[] encryptionKey;
+    @NonNull
+    private final Key key;
 
-    private LiSecuredPrefManager(Context context) throws NoSuchAlgorithmException {
-        String encryptionStr = context.getPackageName() + Settings.Secure.getString(context.getContentResolver(), Settings.Secure.ANDROID_ID);
-        encryptionKey = encryptionStr.getBytes();
-        sha = MessageDigest.getInstance("SHA-1");
-        aesKey = new SecretKeySpec(Arrays.copyOf(sha.digest(encryptionKey), ENCRYPTION_LENGTH), ENCRYPTION_ALGORITHM);
+    /**
+     * Default private constructor.
+     *
+     * @param secret The secret encryption key.
+     * @throws NoSuchAlgorithmException If the device does not support SHA-1 encryption.
+     */
+    private LiSecuredPrefManager(@NonNull String secret) throws NoSuchAlgorithmException, UnsupportedEncodingException {
+        LiCoreSDKUtils.checkNotNull(secret, MessageConstants.wasNull("secret encryption key"));
+        MessageDigest sha = MessageDigest.getInstance("SHA1");
+        key = new SecretKeySpec(Arrays.copyOf(sha.digest(secret.getBytes()), ENCRYPTION_LENGTH), "AES");
     }
 
     /**
-     * Instance of this.
+     * Default initializer.
+     *
+     * @param secret The secret encryption key.
      */
-    public static LiSecuredPrefManager getInstance() {
-        if (instance == null) {
-            Log.e(LI_LOG_TAG, "LiSecuredPrefManager not intialized. Call init method first");
-            return null;
-        }
-        return instance;
-    }
-
-    private static String encode(byte[] input) {
-        return Base64.encodeToString(input, Base64.NO_PADDING | Base64.NO_WRAP);
-    }
-
-    private static byte[] decode(String input) {
-        return Base64.decode(input, Base64.NO_PADDING | Base64.NO_WRAP);
-    }
-
-    public static synchronized LiSecuredPrefManager init(Context context) {
+    public static synchronized void initialize(@NonNull String secret) throws LiInitializationException {
         if (isInitialized.compareAndSet(false, true)) {
             try {
-                instance = new LiSecuredPrefManager(context);
-            } catch (NoSuchAlgorithmException e) {
-                Log.e(LiCoreSDKConstants.LI_LOG_TAG, e.getMessage());
+                instance = new LiSecuredPrefManager(secret);
+            } catch (NoSuchAlgorithmException | UnsupportedEncodingException e) {
+                e.printStackTrace();
+                throw new LiInitializationException(LiSecuredPrefManager.class.getSimpleName(), e);
             }
         }
-        return instance;
-    }
-
-    public String encrypt(String str) throws Exception {
-        Cipher cipher = Cipher.getInstance(ENCRYPTION_ALGORITHM);
-        cipher.init(Cipher.ENCRYPT_MODE, aesKey);
-        return encode(cipher.doFinal(str.getBytes("UTF-8")));
-    }
-
-    public String decrypt(String encrStr) throws Exception {
-        Cipher cipher = Cipher.getInstance(ENCRYPTION_ALGORITHM);
-        cipher.init(Cipher.DECRYPT_MODE, aesKey);
-        return new String(cipher.doFinal(decode(encrStr)), "UTF-8");
     }
 
     /**
-     * fetches shared preference
+     * Deprecated initializer.
      *
-     * @param context {@link Context}
-     * @return SharedPreferences
+     * @param context An Android context.
+     * @return instance of Lithium Secured Preference Manager.
+     * @deprecated Use {@link #initialize(String)} instead.
      */
-    SharedPreferences getSecuredPreferences(Context context) {
-        return context.getSharedPreferences(LiCoreSDKConstants.LI_SHARED_PREFERENCES_NAME,
-                Context.MODE_PRIVATE);
-    }
-
-    public void remove(Context context, String key) {
+    @Deprecated
+    public static synchronized LiSecuredPrefManager init(@NonNull Context context) {
+        LiCoreSDKUtils.checkNotNull(context, MessageConstants.wasNull("context"));
         try {
-            instance.getSecuredPreferences(context).edit().remove(
-                    instance.encrypt(key)).apply();
-        } catch (Exception e) {
-            Log.e(LI_LOG_TAG, "Encryption error, " + e.getMessage());
-            instance.getSecuredPreferences(context).edit().remove(key).apply();
+            initialize(context.getPackageName() + Settings.Secure.getString(context.getContentResolver(), Settings.Secure.ANDROID_ID));
+        } catch (LiInitializationException e) {
+            e.printStackTrace();
         }
+
+        return getInstance();
     }
 
-    public void putString(Context context, String key, String value) {
-        try {
-            instance.getSecuredPreferences(context).edit().putString(
-                    instance.encrypt(key),
-                    instance.encrypt(value)).apply();
-        } catch (Exception e) {
-            Log.e(LI_LOG_TAG, "Encryption error, " + e.getMessage());
-            instance.getSecuredPreferences(context).edit().putString(key, value).apply();
-        }
+    /**
+     * Get instance the of Lia Secured Preference Manager.
+     *
+     * @return Instance of the Secured Preference Manager.
+     */
+    @Nullable
+    public static LiSecuredPrefManager getInstance() {
+        return instance;
     }
 
-    public String getString(Context context, String key) {
-        //get secured preferences and check key has any value there
-        SharedPreferences securedPreferences = instance.getSecuredPreferences(context);
-        String value;
+    @NonNull
+    private static String encode(@NonNull byte[] input) throws UnsupportedEncodingException {
+        return Base64.encodeToString(input, Base64.DEFAULT);
+    }
+
+    @NonNull
+    private static byte[] decode(String input) {
+        return Base64.decode(input, Base64.DEFAULT);
+    }
+
+    /**
+     * Get the instance of the shared preference.
+     *
+     * @return Lia Shared Preferences.
+     */
+    @NonNull
+    private SharedPreferences getSecuredPreferences(@NonNull Context context) {
+        LiCoreSDKUtils.checkNotNull(context, MessageConstants.wasNull("context"));
+        return context.getSharedPreferences(LiCoreSDKConstants.LI_SHARED_PREFERENCES_NAME, Context.MODE_PRIVATE);
+    }
+
+    /**
+     * Get a value of a preference.
+     *
+     * @param context An Android Context.
+     * @param key     The preference key.
+     * @return The value of the key or {@code null} if {@code key} does not exist.
+     */
+    @Nullable
+    public String getString(@NonNull Context context, @NonNull String key) {
+        LiCoreSDKUtils.checkNotNull(context, MessageConstants.wasNull("context"));
+        LiCoreSDKUtils.checkNullOrNotEmpty(key, MessageConstants.wasNull("key"));
+        SharedPreferences preferences = getSecuredPreferences(context);
+        String value = null;
         try {
-            value = instance.decrypt(securedPreferences.getString(instance.encrypt(key), null));
-            if (value == null) {
-                //if not present then check in old unencrypted preferences and then move it new encrypted preferences
-                // file
-                value = securedPreferences.getString(key, null);
-                putString(context, key, value);
-                securedPreferences.edit().remove(key).apply();
+            String encryptedKey = encrypt(key);
+            String encryptedValue = preferences.getString(encryptedKey, null);
+            if (encryptedValue != null) {
+                value = decrypt(encryptedValue);
             }
-        } catch (Exception e) {
-            Log.e(LI_LOG_TAG, "Encryption error, " + e.getMessage());
-            value = securedPreferences.getString(key, null);
+        } catch (NoSuchAlgorithmException | InvalidKeyException | NoSuchPaddingException | BadPaddingException | UnsupportedEncodingException |
+                IllegalBlockSizeException e) {
+            e.printStackTrace();
+            value = preferences.getString(key, null);
         }
         return value;
+    }
+
+    /**
+     * Saves a key and value in preference.
+     *
+     * @param context An Android Context.
+     * @param key     The preference key.
+     * @param value   Its value.
+     */
+    public void putString(@NonNull Context context, @NonNull String key, @NonNull String value) {
+        LiCoreSDKUtils.checkNotNull(context, MessageConstants.wasNull("context"));
+        LiCoreSDKUtils.checkNullOrNotEmpty(key, MessageConstants.wasNull("key"));
+        LiCoreSDKUtils.checkNullOrNotEmpty(key, MessageConstants.wasNull("value"));
+        try {
+            String encryptedKey = encrypt(key);
+            String encryptedValue = encrypt(value);
+            getSecuredPreferences(context).edit().putString(encryptedKey, encryptedValue).apply();
+        } catch (NoSuchAlgorithmException | InvalidKeyException | NoSuchPaddingException | BadPaddingException | UnsupportedEncodingException |
+                IllegalBlockSizeException e) {
+            e.printStackTrace();
+            getSecuredPreferences(context).edit().putString(key, value).apply();
+        }
+    }
+
+    /**
+     * Removes a saved preference.
+     *
+     * @param context An Android Context.
+     * @param key     The preference key.
+     */
+    public void remove(@NonNull Context context, @NonNull String key) {
+        LiCoreSDKUtils.checkNotNull(context, MessageConstants.wasNull("context"));
+        LiCoreSDKUtils.checkNullOrNotEmpty(key, MessageConstants.wasNull("key"));
+        try {
+            String encryptedString = encrypt(key);
+            getSecuredPreferences(context).edit().remove(encryptedString).apply();
+        } catch (Exception e) {
+            e.printStackTrace();
+            getSecuredPreferences(context).edit().remove(key).apply();
+        }
+    }
+
+    @NonNull
+    private String encrypt(@NonNull String string) throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeyException,
+            UnsupportedEncodingException, BadPaddingException, IllegalBlockSizeException {
+        @SuppressLint("GetInstance")
+        Cipher cipher = Cipher.getInstance(ENCRYPTION_ALGORITHM);
+        cipher.init(Cipher.ENCRYPT_MODE, key);
+        byte[] bytes = string.getBytes();
+        byte[] encrypted = cipher.doFinal(bytes);
+        return encode(encrypted);
+    }
+
+    @NonNull
+    private String decrypt(@NonNull String string) throws NoSuchPaddingException, NoSuchAlgorithmException, InvalidKeyException,
+            BadPaddingException, IllegalBlockSizeException, UnsupportedEncodingException {
+        @SuppressLint("GetInstance")
+        Cipher cipher = Cipher.getInstance(ENCRYPTION_ALGORITHM);
+        cipher.init(Cipher.DECRYPT_MODE, key);
+        byte[] decoded = decode(string);
+        byte[] decrypted = cipher.doFinal(decoded);
+        return new String(decrypted);
     }
 }

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiSecuredPrefManager.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiSecuredPrefManager.java
@@ -159,8 +159,8 @@ class LiSecuredPrefManager {
             if (encryptedValue != null) {
                 value = decrypt(encryptedValue);
             }
-        } catch (NoSuchAlgorithmException | InvalidKeyException | NoSuchPaddingException | BadPaddingException | UnsupportedEncodingException |
-                IllegalBlockSizeException e) {
+        } catch (NoSuchAlgorithmException | InvalidKeyException | NoSuchPaddingException
+                | BadPaddingException | UnsupportedEncodingException | IllegalBlockSizeException e) {
             e.printStackTrace();
             value = preferences.getString(key, null);
         }
@@ -182,8 +182,8 @@ class LiSecuredPrefManager {
             String encryptedKey = encrypt(key);
             String encryptedValue = encrypt(value);
             getSecuredPreferences(context).edit().putString(encryptedKey, encryptedValue).apply();
-        } catch (NoSuchAlgorithmException | InvalidKeyException | NoSuchPaddingException | BadPaddingException | UnsupportedEncodingException |
-                IllegalBlockSizeException e) {
+        } catch (NoSuchAlgorithmException | InvalidKeyException | NoSuchPaddingException
+                | BadPaddingException | UnsupportedEncodingException | IllegalBlockSizeException e) {
             e.printStackTrace();
             getSecuredPreferences(context).edit().putString(key, value).apply();
         }

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/model/helpers/LiModerationStatus.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/model/helpers/LiModerationStatus.java
@@ -78,7 +78,7 @@ public enum LiModerationStatus {
     MARKED_REJECTED;
 
     public static LiModerationStatus fromString(String moderationStatus) {
-        if (LiCoreSDKUtils.checkNullOrNotEmpty(moderationStatus, null) != null) {
+        if (LiCoreSDKUtils.checkNotNullAndNotEmpty(moderationStatus, null) != null) {
             return LiModerationStatus.UNKNOWN;
         }
 

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/model/response/LiSubscriptions.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/model/response/LiSubscriptions.java
@@ -19,7 +19,6 @@ package lithium.community.android.sdk.model.response;
 import com.google.gson.JsonObject;
 import com.google.gson.annotations.SerializedName;
 
-import lithium.community.android.sdk.exception.LiRestResponseException;
 import lithium.community.android.sdk.manager.LiClientManager;
 import lithium.community.android.sdk.model.LiBaseModelImpl;
 import lithium.community.android.sdk.model.helpers.LiBoard;
@@ -65,11 +64,7 @@ public class LiSubscriptions extends LiBaseModelImpl implements LiTargetModel {
 
     public LiMessage getLiMessage() {
         if (targetObject.has("type") && targetObject.get("type").getAsString().equals("message")) {
-            try {
-                return LiClientManager.getRestClient().getGson().fromJson(targetObject.toString(), LiMessage.class);
-            } catch (LiRestResponseException e) {
-                return null;
-            }
+            return LiClientManager.getRestClient().getGson().fromJson(targetObject.toString(), LiMessage.class);
         } else {
             return null;
         }
@@ -77,11 +72,7 @@ public class LiSubscriptions extends LiBaseModelImpl implements LiTargetModel {
 
     public LiBoard getLiBoard() {
         if (targetObject.has("type") && targetObject.get("type").getAsString().equals("board")) {
-            try {
-                return LiClientManager.getRestClient().getGson().fromJson(targetObject.toString(), LiBoard.class);
-            } catch (LiRestResponseException e) {
-                return null;
-            }
+            return LiClientManager.getRestClient().getGson().fromJson(targetObject.toString(), LiBoard.class);
         } else {
             return null;
         }

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/queryutil/LiDefaultQueryHelper.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/queryutil/LiDefaultQueryHelper.java
@@ -17,6 +17,8 @@
 package lithium.community.android.sdk.queryutil;
 
 import android.content.Context;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.util.Log;
 import android.util.NoSuchPropertyException;
 
@@ -25,37 +27,40 @@ import com.google.gson.JsonParser;
 
 import lithium.community.android.sdk.R;
 import lithium.community.android.sdk.utils.LiCoreSDKUtils;
+import lithium.community.android.sdk.utils.MessageConstants;
 
 /**
- * This class is use to fetch default query settings for LIQL calls from the 'raw' package of the core SDK.
- * Created by shoureya.kant on 1/12/17.
+ * This class is use to fetch default LIQL query settings for LIQL calls.
+ *
+ * @author shoureya.kant, adityasharat
  */
-
 public class LiDefaultQueryHelper {
 
     private static LiDefaultQueryHelper instance;
+
+    @Nullable
     private JsonObject defaultSetting;
 
     /**
-     * private constructor.
+     * Default private constructor.
      *
      * @param context {@link Context}
      */
     private LiDefaultQueryHelper(Context context) {
+        LiCoreSDKUtils.checkNotNull(context, MessageConstants.wasNull("context"));
         defaultSetting = getDefaultQueryJSON(context);
     }
 
     /**
-     * Initializes helper class.
+     * Initializes the singleton instance of the Lithium Query Helper
      *
      * @param context {@link Context}
-     * @return Singleton instance of this class.
      */
-    public static synchronized LiDefaultQueryHelper initHelper(Context context) {
+    public static synchronized void initialize(@NonNull Context context) {
+        LiCoreSDKUtils.checkNotNull(context, MessageConstants.wasNull("context"));
         if (instance == null) {
             instance = new LiDefaultQueryHelper(context);
         }
-        return instance;
     }
 
     /**
@@ -69,30 +74,45 @@ public class LiDefaultQueryHelper {
     }
 
     /**
-     * Fetches default settings from 'raw' package
+     * Initializes helper class.
      *
      * @param context {@link Context}
-     * @return default settings in JsonObject form.
+     * @return instance of Lithium Query Helper.
+     * @deprecated Use {@link #initialize(Context)}
      */
-    private static JsonObject getDefaultQueryJSON(Context context) {
-        int rawResId = R.raw.li_default_query_settings;
-        JsonObject defaultQuerySettingsJson = null;
-        String defaultJsonString = null;
+    public static synchronized LiDefaultQueryHelper initHelper(Context context) {
+        if (instance == null) {
+            instance = new LiDefaultQueryHelper(context);
+        }
+        return instance;
+    }
 
-        defaultJsonString = LiCoreSDKUtils.getRawString(context, rawResId);
+    /**
+     * Fetches default settings packaged with the SDK.
+     *
+     * @param context An Android context.
+     * @return default SDK settings.
+     */
+    @Nullable
+    private static JsonObject getDefaultQueryJSON(@NonNull Context context) {
+        int rawResId = R.raw.li_default_query_settings;
+        String string = LiCoreSDKUtils.getRawString(context, rawResId);
+        JsonObject settings = null;
 
         try {
-            // Parse the data into jsonobject to get original data in form of json.
-            defaultQuerySettingsJson = new JsonParser().parse(defaultJsonString).getAsJsonObject();
+            settings = new JsonParser().parse(string).getAsJsonObject();
         } catch (Exception e) {
-            Log.e("LiDefaultQueryHelper", "Could not parse default query settings");
+            Log.e("LiDefaultQueryHelper", "Could not parse the default SDK settings");
+            //e.printStackTrace();
         }
-        return defaultQuerySettingsJson;
+
+        return settings;
     }
 
     /**
      * @return default settings
      */
+    @Nullable
     public JsonObject getDefaultSetting() {
         return defaultSetting;
     }

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/queryutil/LiDefaultQueryHelper.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/queryutil/LiDefaultQueryHelper.java
@@ -45,7 +45,7 @@ public class LiDefaultQueryHelper {
      *
      * @param context {@link Context}
      */
-    private LiDefaultQueryHelper(Context context) {
+    private LiDefaultQueryHelper(@NonNull Context context) {
         LiCoreSDKUtils.checkNotNull(context, MessageConstants.wasNull("context"));
         defaultSetting = getDefaultQueryJSON(context);
     }
@@ -79,10 +79,8 @@ public class LiDefaultQueryHelper {
      */
     @Deprecated
     public static synchronized LiDefaultQueryHelper initHelper(Context context) {
-        if (instance == null) {
-            instance = new LiDefaultQueryHelper(context);
-        }
-        return instance;
+        initialize(context);
+        return getInstance();
     }
 
     /**
@@ -101,7 +99,7 @@ public class LiDefaultQueryHelper {
             settings = new JsonParser().parse(string).getAsJsonObject();
         } catch (Exception e) {
             Log.e("LiDefaultQueryHelper", "Could not parse the default SDK settings");
-            //e.printStackTrace();
+            e.printStackTrace();
         }
 
         return settings;

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/queryutil/LiDefaultQueryHelper.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/queryutil/LiDefaultQueryHelper.java
@@ -20,7 +20,6 @@ import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.util.Log;
-import android.util.NoSuchPropertyException;
 
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
@@ -66,10 +65,8 @@ public class LiDefaultQueryHelper {
     /**
      * @return Instance of this class.
      */
+    @Nullable
     public static LiDefaultQueryHelper getInstance() {
-        if (instance == null) {
-            throw new NoSuchPropertyException("Helper not intialized. Call init method first");
-        }
         return instance;
     }
 
@@ -80,6 +77,7 @@ public class LiDefaultQueryHelper {
      * @return instance of Lithium Query Helper.
      * @deprecated Use {@link #initialize(Context)}
      */
+    @Deprecated
     public static synchronized LiDefaultQueryHelper initHelper(Context context) {
         if (instance == null) {
             instance = new LiDefaultQueryHelper(context);

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/rest/LiRestClient.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/rest/LiRestClient.java
@@ -164,10 +164,10 @@ public abstract class LiRestClient {
         LiCoreSDKUtils.checkNotNull(baseRestRequest, MessageConstants.wasNull("baseRestRequest"));
         if (baseRestRequest.isAuthenticatedRequest() && sdkManager.isUserLoggedIn()) {
             if (sdkManager.getNeedsTokenRefresh()) {
-                Log.d(TOKEN_REFRESH_TAG, "Refresh Token expired on device, fetching again: " + sdkManager.getNewAuthToken());
+                Log.d(TOKEN_REFRESH_TAG, "Refresh Token expired on device, fetching again: " + sdkManager.getAuthToken());
                 LiTokenResponse liTokenResponse = new LiAuthServiceImpl(baseRestRequest.getContext(), sdkManager).performSyncRefreshTokenRequest();
                 sdkManager.persistAuthState(baseRestRequest.getContext(), liTokenResponse);
-                Log.d(TOKEN_REFRESH_TAG, "Fetched new refresh token: " + sdkManager.getNewAuthToken());
+                Log.d(TOKEN_REFRESH_TAG, "Fetched new refresh token: " + sdkManager.getAuthToken());
             }
         }
 
@@ -209,12 +209,12 @@ public abstract class LiRestClient {
         if (baseRestRequest.isAuthenticatedRequest() && sdkManager.isUserLoggedIn()) {
             if (sdkManager.getNeedsTokenRefresh()) {
                 try {
-                    Log.d(TOKEN_REFRESH_TAG, "Refresh Token expired on device, fetching again: " + sdkManager.getNewAuthToken());
+                    Log.d(TOKEN_REFRESH_TAG, "Refresh Token expired on device, fetching again: " + sdkManager.getAuthToken());
                     sdkManager.fetchFreshAccessToken(baseRestRequest.getContext(), new LiAuthServiceImpl.FreshTokenCallBack() {
                         @Override
                         public void onFreshTokenFetched(boolean isFetched) {
                             if (isFetched) {
-                                Log.d(TOKEN_REFRESH_TAG, "Fetched new refresh token: " + sdkManager.getNewAuthToken());
+                                Log.d(TOKEN_REFRESH_TAG, "Fetched new refresh token: " + sdkManager.getAuthToken());
                                 enqueueCall(baseRestRequest, callback);
                             } else {
                                 callback.onError(LiRestResponseException.networkError("Could not refresh token"));
@@ -289,11 +289,11 @@ public abstract class LiRestClient {
         if (baseRestRequest.isAuthenticatedRequest() && sdkManager.isUserLoggedIn()) {
             if (sdkManager.getNeedsTokenRefresh()) {
                 try {
-                    Log.d(TOKEN_REFRESH_TAG, "Refresh Token expired on device, fetching again: " + sdkManager.getNewAuthToken());
+                    Log.d(TOKEN_REFRESH_TAG, "Refresh Token expired on device, fetching again: " + sdkManager.getAuthToken());
                     sdkManager.fetchFreshAccessToken(baseRestRequest.getContext(), new LiAuthServiceImpl.FreshTokenCallBack() {
                         @Override
                         public void onFreshTokenFetched(boolean isFetched) {
-                            Log.d(TOKEN_REFRESH_TAG, "Fetched new refresh token: " + sdkManager.getNewAuthToken());
+                            Log.d(TOKEN_REFRESH_TAG, "Fetched new refresh token: " + sdkManager.getAuthToken());
                             uploadEnqueueCall(baseRestRequest, callback, imagePath, imageName, requestBody);
                         }
                     });
@@ -334,7 +334,7 @@ public abstract class LiRestClient {
         }
 
         Uri.Builder uriBuilder = new Uri.Builder().scheme("https");
-        String proxyHost = sdkManager.getProxyHost();
+        String proxyHost = sdkManager.getApiGatewayHost();
 
         uriBuilder.authority(proxyHost);
         uriBuilder.appendEncodedPath(baseRestRequest.getPath());
@@ -432,7 +432,7 @@ public abstract class LiRestClient {
      */
     protected Request buildRequest(LiBaseRestRequest baseRestRequest) {
         Uri.Builder uriBuilder = new Uri.Builder().scheme("https");
-        uriBuilder.authority(sdkManager.getProxyHost());
+        uriBuilder.authority(sdkManager.getApiGatewayHost());
         uriBuilder.appendEncodedPath(baseRestRequest.getPath());
         if (baseRestRequest.getQueryParams() != null) {
             for (String param : baseRestRequest.getQueryParams().keySet()) {
@@ -457,8 +457,8 @@ public abstract class LiRestClient {
     @NonNull
     private Request.Builder buildRequestHeaders(Context context, Request.Builder requestBuilder) {
 
-        if (!TextUtils.isEmpty(sdkManager.getNewAuthToken())) {
-            requestBuilder.header(LiAuthConstants.AUTHORIZATION, LiAuthConstants.BEARER + sdkManager.getNewAuthToken());
+        if (!TextUtils.isEmpty(sdkManager.getAuthToken())) {
+            requestBuilder.header(LiAuthConstants.AUTHORIZATION, LiAuthConstants.BEARER + sdkManager.getAuthToken());
         }
         requestBuilder.header(LiRequestHeaderConstants.LI_REQUEST_CONTENT_TYPE, "application/json");
         requestBuilder.header(LiRequestHeaderConstants.LI_REQUEST_CLIENT_ID, sdkManager.getCredentials().getClientKey());
@@ -573,7 +573,7 @@ public abstract class LiRestClient {
 
                             request = request.newBuilder().removeHeader(LiAuthConstants.AUTHORIZATION).build();
 
-                            request = request.newBuilder().addHeader(LiAuthConstants.AUTHORIZATION, LiAuthConstants.BEARER + sdkManager.getNewAuthToken())
+                            request = request.newBuilder().addHeader(LiAuthConstants.AUTHORIZATION, LiAuthConstants.BEARER + sdkManager.getAuthToken())
                                     .build();
                         } catch (LiRestResponseException e) {
                             Log.e(LOG_TAG, "Error making rest call for refresh token", e);

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/rest/LiRestClient.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/rest/LiRestClient.java
@@ -186,6 +186,7 @@ public abstract class LiRestClient {
      * @throws IllegalArgumentException  if the SDK is not initialized.
      * @deprecated Use {@link #LiRestClient(LiSDKManager)} instead
      */
+    @Deprecated
     public LiRestClient() throws LiInitializationException {
         this(LiCoreSDKUtils.checkNotNull(LiSDKManager.getInstance(), MessageConstants.wasNull("Li SDK Manager")));
     }

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/rest/LiRestv2Client.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/rest/LiRestv2Client.java
@@ -17,6 +17,7 @@
 package lithium.community.android.sdk.rest;
 
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.util.Log;
 
 import com.google.gson.Gson;
@@ -37,8 +38,24 @@ public class LiRestv2Client extends LiRestClient {
 
     private static final String LOG_TAG = "LiRestv2Client";
 
+    private static LiRestv2Client instance;
+
     private LiRestv2Client(@NonNull LiSDKManager manager) throws LiInitializationException {
         super(manager);
+    }
+
+    /**
+     * <p>
+     * Initializes the Rest Client singleton. If the initialization is successful {@link #getInstance()} will
+     * return an initialized SDK Manager. This function may or may not create a new instance or reinitialize
+     * with subsequent calls.
+     * </p>
+     *
+     * @param manager A Li SDK manager
+     * @throws LiInitializationException if the Rest client fails to initialize.
+     */
+    public static void initialize(@NonNull LiSDKManager manager) throws LiInitializationException {
+        instance = new LiRestv2Client(manager);
     }
 
     /**
@@ -46,8 +63,17 @@ public class LiRestv2Client extends LiRestClient {
      *
      * @return Instance of this class.
      */
+    @Nullable
     public static LiRestv2Client getInstance() {
-        return LiRestV2ClientInitializer.LI_RESTV_2_CLIENT;
+        if (instance == null) {
+            try {
+                //noinspection ConstantConditions to support backwards compatibility
+                initialize(LiSDKManager.getInstance());
+            } catch (LiInitializationException e) {
+                e.printStackTrace();
+            }
+        }
+        return instance;
     }
 
     /**
@@ -170,25 +196,6 @@ public class LiRestv2Client extends LiRestClient {
         } else {
             Log.e(LOG_TAG, "Error response from server");
             throw LiRestResponseException.fromJson(jsonObject.getAsString(), gson);
-        }
-    }
-
-    /**
-     * Initializer for LiRestV2Client.
-     */
-    private static class LiRestV2ClientInitializer {
-
-        private static final LiRestv2Client LI_RESTV_2_CLIENT;
-
-        static {
-            LiRestv2Client instance;
-            try {
-                instance = new LiRestv2Client(LiCoreSDKUtils.checkNotNull(LiSDKManager.getInstance(), MessageConstants.wasNull("SDK Manager")));
-            } catch (LiInitializationException e) {
-                instance = null;
-                e.printStackTrace();
-            }
-            LI_RESTV_2_CLIENT = instance;
         }
     }
 }

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/rest/LiRestv2Client.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/rest/LiRestv2Client.java
@@ -67,6 +67,7 @@ public class LiRestv2Client extends LiRestClient {
     public static LiRestv2Client getInstance() {
         if (instance == null) {
             try {
+                // TODO: remove this in next major version.
                 //noinspection ConstantConditions to support backwards compatibility
                 initialize(LiSDKManager.getInstance());
             } catch (LiInitializationException e) {

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/utils/LiCoreSDKUtils.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/utils/LiCoreSDKUtils.java
@@ -58,6 +58,7 @@ import okhttp3.Request;
  * Utility class for common operations.
  */
 public class LiCoreSDKUtils {
+
     private static final int INITIAL_READ_BUFFER_SIZE = 1024;
     private static final ThreadLocal<SecureRandom> RAND_TL = new ThreadLocal<SecureRandom>() {
         @Override
@@ -437,24 +438,24 @@ public class LiCoreSDKUtils {
      * @return String is the raw file.
      */
     public static String getRawString(Context context, int rawResId) {
-        String defaultJsonString;
         InputStream inputStream = context.getResources().openRawResource(rawResId);
-        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-        int readPointer;
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        int _char;
         try {
             if (inputStream != null) {
-                readPointer = inputStream.read();
-                while (readPointer != -1) {
-                    byteArrayOutputStream.write(readPointer);
-                    readPointer = inputStream.read();
+                _char = inputStream.read();
+                while (_char != -1) {
+                    outputStream.write(_char);
+                    _char = inputStream.read();
                 }
                 inputStream.close();
             }
         } catch (IOException e) {
-            Log.e("Default JSON read", e.getMessage());
+            Log.e("Util", "#getRawString() failed.");
+            e.printStackTrace();
         }
-        defaultJsonString = byteArrayOutputStream.toString();
-        return defaultJsonString;
+
+        return outputStream.toString();
     }
 
     public static Long getTime(Long time) {

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/utils/LiCoreSDKUtils.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/utils/LiCoreSDKUtils.java
@@ -156,7 +156,7 @@ public class LiCoreSDKUtils {
      * Ensures that the string is either null, or a non-empty string.
      */
     @NonNull
-    public static String checkNullOrNotEmpty(String input, @Nullable String errorMessage) {
+    public static String checkNotNullAndNotEmpty(String input, @Nullable String errorMessage) {
         checkNotNull(input, errorMessage);
         checkArgument(!TextUtils.isEmpty(input), errorMessage != null ? errorMessage : "Argument was an empty string");
         return input;

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/utils/LiCoreSDKUtils.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/utils/LiCoreSDKUtils.java
@@ -440,13 +440,13 @@ public class LiCoreSDKUtils {
     public static String getRawString(Context context, int rawResId) {
         InputStream inputStream = context.getResources().openRawResource(rawResId);
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        int _char;
+        int character;
         try {
             if (inputStream != null) {
-                _char = inputStream.read();
-                while (_char != -1) {
-                    outputStream.write(_char);
-                    _char = inputStream.read();
+                character = inputStream.read();
+                while (character != -1) {
+                    outputStream.write(character);
+                    character = inputStream.read();
                 }
                 inputStream.close();
             }

--- a/li-android-sdk-core/src/test/java/lithium/community/android/sdk/LiSDKManagerTest.java
+++ b/li-android-sdk-core/src/test/java/lithium/community/android/sdk/LiSDKManagerTest.java
@@ -28,16 +28,19 @@ import org.junit.runners.MethodSorters;
 import org.mockito.MockitoAnnotations;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import java.lang.reflect.Field;
 import java.net.URISyntaxException;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import lithium.community.android.sdk.auth.LiAppCredentials;
 import lithium.community.android.sdk.exception.LiInitializationException;
 import lithium.community.android.sdk.manager.LiSDKManager;
+import lithium.community.android.sdk.manager.LiSecuredPrefManager;
 
 import static org.junit.Assert.assertEquals;
 
 /**
- * @author aiteja.tokala, adityasharat
+ * @author saiteja.tokala, adityasharat
  */
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 @RunWith(MockitoJUnitRunner.class)
@@ -51,6 +54,22 @@ public class LiSDKManagerTest {
     public void setUpTest() throws Exception {
         MockitoAnnotations.initMocks(this);
         mContext = TestHelper.createMockContext();
+
+        Field instance = LiSecuredPrefManager.class.getDeclaredField("instance");
+        instance.setAccessible(true);
+        instance.set(null, null);
+        Field isInitialized = LiSecuredPrefManager.class.getDeclaredField("isInitialized");
+        isInitialized.setAccessible(true);
+        isInitialized.set(null, new AtomicBoolean(false));
+
+        instance = LiSDKManager.class.getDeclaredField("instance");
+        instance.setAccessible(true);
+        instance.set(null, null);
+        isInitialized = LiSDKManager.class.getDeclaredField("isInitialized");
+        isInitialized.setAccessible(true);
+        isInitialized.set(null, new AtomicBoolean(false));
+
+        LiSDKManager.initialize(mContext, TestHelper.getTestAppCredentials());
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/li-android-sdk-core/src/test/java/lithium/community/android/sdk/LiSDKManagerTest.java
+++ b/li-android-sdk-core/src/test/java/lithium/community/android/sdk/LiSDKManagerTest.java
@@ -16,9 +16,7 @@
 
 package lithium.community.android.sdk;
 
-import android.app.Activity;
-import android.content.SharedPreferences;
-import android.content.res.Resources;
+import android.content.Context;
 
 import org.junit.Before;
 import org.junit.FixMethodOrder;
@@ -37,10 +35,6 @@ import lithium.community.android.sdk.exception.LiInitializationException;
 import lithium.community.android.sdk.manager.LiSDKManager;
 
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * @author aiteja.tokala, adityasharat
@@ -51,18 +45,12 @@ public class LiSDKManagerTest {
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();
-    private Activity mContext;
+    private Context mContext;
 
     @Before
     public void setUpTest() throws Exception {
         MockitoAnnotations.initMocks(this);
-        mContext = mock(Activity.class);
-        SharedPreferences mMockSharedPreferences = mock(SharedPreferences.class);
-        Resources resource = mock(Resources.class);
-        when(resource.getBoolean(anyInt())).thenReturn(true);
-        when(mContext.getSharedPreferences(anyString(), anyInt())).thenReturn(mMockSharedPreferences);
-        when(mMockSharedPreferences.getString(anyString(), anyString())).thenReturn("foobar");
-        when(mContext.getResources()).thenReturn(resource);
+        mContext = TestHelper.createMockContext();
     }
 
     @Test(expected = IllegalArgumentException.class)

--- a/li-android-sdk-core/src/test/java/lithium/community/android/sdk/TestHelper.java
+++ b/li-android-sdk-core/src/test/java/lithium/community/android/sdk/TestHelper.java
@@ -16,40 +16,31 @@
 
 package lithium.community.android.sdk;
 
-import android.net.Uri;
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.content.res.Resources;
+
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
 
 import lithium.community.android.sdk.auth.LiAppCredentials;
+
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.anyString;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.when;
 
 /**
  * Contains common test values which are useful across all tests.
  */
 public class TestHelper {
 
-    /**
-     * For requesting an authorization code.
-     *
-     * @see <a href="https://tools.ietf.org/html/rfc6749#section-3.1.1"> "The OAuth 2.0
-     * Authorization Framework" (RFC 6749), Section 3.1.1</a>
-     */
-    public static final String CODE = "code";
-
-    /**
-     * For requesting an access token via an implicit grant.
-     *
-     * @see <a href="https://tools.ietf.org/html/rfc6749#section-3.1.1"> "The OAuth 2.0
-     * Authorization Framework" (RFC 6749), Section 3.1.1</a>
-     */
-    public static final String TOKEN = "token";
-
-    /**
-     * For requesting an OpenID Conenct ID Token.
-     *
-     * @see <a href="http://openid.net/specs/openid-connect-core-1_0.html#IDToken">
-     * "OpenID Connect Core 1.0", Section 2</a>
-     */
-    public static final String ID_TOKEN = "id_token";
-
-    public static final String APPLICATION_TYPE_NATIVE = "native";
 
     public static final String TEST_CLIENT_NAME = "test";
     public static final String TEST_CLIENT_ID = "mj2gw0IYuoo33m0rKxuX4KpxUfsy7Q0rcBJhq34GHgs=";
@@ -57,228 +48,265 @@ public class TestHelper {
     public static final String TEST_TENANT_ID = "test";
     public static final String TEST_CLIENT_SECRET = "test_client_secret";
     public static final String TEST_COMMUNITY_URL = "http://community.lithium.com";
-
-    public static final String TEST_STATE = "$TAT3";
-    public static final String TEST_APP_SCHEME = "com.test.app";
-
-    public static final Uri TEST_APP_REDIRECT_URI = Uri.parse(TEST_APP_SCHEME + ":/oidc_callback");
-
-    public static final String TEST_SCOPE = "openid email";
-
-    public static final Uri TEST_IDP_AUTH_ENDPOINT = Uri.parse("https://testidp.example.com/authorize");
-    public static final Uri TEST_IDP_TOKEN_ENDPOINT = Uri.parse("https://testidp.example.com/token");
-    public static final Uri TEST_IDP_REGISTRATION_ENDPOINT = Uri.parse("https://testidp.example.com/token");
-
-    public static final String TEST_CODE_VERIFIER = "0123456789_0123456789_0123456789_0123456789";
-    public static final String TEST_AUTH_CODE = "zxcvbnmjk";
-    public static final String TEST_ACCESS_TOKEN = "aaabbbccc";
-    public static final String TEST_ID_TOKEN = "abc.def.ghi";
-    public static final String TEST_REFRESH_TOKEN = "asdfghjkl";
-    public static final Long TEST_ACCESS_TOKEN_EXPIRATION_TIME = 120000L; // two minutes
-
-    public static final Long TEST_CLIENT_SECRET_EXPIRES_AT = 78L;
-
-    public static final String TEST_EMAIL_ADDRESS = "test@example.com";
-
     public static final String DEFAULT_QUERY_SETTINGS = "{\n" +
-            "\t\"article\": {\n" +
-            "\t\t\"liDataSource\": \"messages\",\n" +
-            "\t\t\"whereClauses\": [{\n" +
-            "\t\t\t\"clause\": \"in\",\n" +
-            "\t\t\t\"key\": \"conversation.style\",\n" +
-            "\t\t\t\"value\": \"('forum', 'blog')\",\n" +
-            "\t\t\t\"operator\": \"AND\"\n" +
-            "\t\t}, {\n" +
-            "\t\t\t\"clause\": \"equals\",\n" +
-            "\t\t\t\"key\": \"depth\",\n" +
-            "\t\t\t\"value\": \"##\",\n" +
-            "\t\t\t\"operator\": \"or\"\n" +
-            "\t\t}],\n" +
-            "\t\t\"ordering\": {\n" +
-            "\t\t\t\"key\": \"conversation.last_post_time\",\n" +
-            "\t\t\t\"type\": \"desc\"\n" +
-            "\t\t},\n" +
-            "\t\t\"limit\": \"50\"\n" +
-            "\t},\n" +
-            "\t\"test\": {\n" +
-            "\t\t\"liDataSource\": \"test\",\n" +
-            "\t\t\"whereClauses\": [{\n" +
-            "\t\t\t\"clause\": \"equals\",\n" +
-            "\t\t\t\"key\": \"target.type\",\n" +
-            "\t\t\t\"value\": \"'test'\",\n" +
-            "\t\t\t\"operator\": \"AND\"\n" +
-            "\t\t}],\n" +
-            "\t\t\"limit\": \"25\"\n" +
-            "\t},\n" +
-            "\t\"node\": {\n" +
-            "\t\t\"liDataSource\": \"nodes\",\n" +
-            "\t\t\"whereClauses\": [{\n" +
-            "\t\t\t\"clause\": \"in\",\n" +
-            "\t\t\t\"key\": \"conversation_style\",\n" +
-            "\t\t\t\"value\": \"('forum', 'blog')\",\n" +
-            "\t\t\t\"operator\": \"AND\"\n" +
-            "\t\t}, {\n" +
-            "\t\t\t\"clause\": \"equals\",\n" +
-            "\t\t\t\"key\": \"parent.id\",\n" +
-            "\t\t\t\"value\": \"'##'\",\n" +
-            "\t\t\t\"operator\": \"and\"\n" +
-            "\t\t}],\n" +
-            "\t\t\"limit\": \"25\"\n" +
-            "\t},\n" +
-            "\t\"search\": {\n" +
-            "\t\t\"liDataSource\": \"messages\",\n" +
-            "\t\t\"whereClauses\": [{\n" +
-            "\t\t\t\"clause\": \"matches\",\n" +
-            "\t\t\t\"key\": \"body\",\n" +
-            "\t\t\t\"value\": \"'##'\",\n" +
-            "\t\t\t\"operator\": \"OR\"\n" +
-            "\t\t}, {\n" +
-            "\t\t\t\"clause\": \"matches\",\n" +
-            "\t\t\t\"key\": \"subject\",\n" +
-            "\t\t\t\"value\": \"'##'\",\n" +
-            "\t\t\t\"operator\": \"OR\"\n" +
-            "\t\t}, {\n" +
-            "\t\t\t\"clause\": \"matches\",\n" +
-            "\t\t\t\"key\": \"tags.text\",\n" +
-            "\t\t\t\"value\": \"'##'\",\n" +
-            "\t\t\t\"operator\": \"OR\"\n" +
-            "\t\t}, {\n" +
-            "\t\t\t\"clause\": \"matches\",\n" +
-            "\t\t\t\"key\": \"labels.text\",\n" +
-            "\t\t\t\"value\": \"'##'\",\n" +
-            "\t\t\t\"operator\": \"AND\"\n" +
-            "\t\t}, {\n" +
-            "\t\t\t\"clause\": \"in\",\n" +
-            "\t\t\t\"key\": \"conversation.style\",\n" +
-            "\t\t\t\"value\": \"('forum', 'blog')\",\n" +
-            "\t\t\t\"operator\": \"OR\"\n" +
-            "\t\t}, {\n" +
-            "\t\t\t\"clause\": \"equals\",\n" +
-            "\t\t\t\"key\": \"depth\",\n" +
-            "\t\t\t\"value\": \"0\",\n" +
-            "\t\t\t\"operator\": \"and\"\n" +
-            "\t\t}],\n" +
-            "\t\t\"ordering\": {\n" +
-            "\t\t\t\"key\": \"conversation.last_post_time\",\n" +
-            "\t\t\t\"type\": \"desc\"\n" +
-            "\t\t},\n" +
-            "\t\t\"limit\": \"25\"\n" +
-            "\t},\n" +
-            "\t\"subscription\": {\n" +
-            "\t\t\"liDataSource\": \"subscriptions\",\n" +
-            "\t\t\"whereClauses\": [{\n" +
-            "\t\t\t\"clause\": \"equals\",\n" +
-            "\t\t\t\"key\": \"target.type\",\n" +
-            "\t\t\t\"value\": \"'message'\",\n" +
-            "\t\t\t\"operator\": \"AND\"\n" +
-            "\t\t}],\n" +
-            "\t\t\"limit\": \"25\"\n" +
-            "\t},\n" +
-            "\t\"message_children\": {\n" +
-            "\t\t\"liDataSource\": \"messages\",\n" +
-            "\t\t\"whereClauses\": [{\n" +
-            "\t\t\t\"clause\": \"equals\",\n" +
-            "\t\t\t\"key\": \"parent.id\",\n" +
-            "\t\t\t\"value\": \"'##'\",\n" +
-            "\t\t\t\"operator\": \"or\"\n" +
-            "\t\t}]\n" +
-            "\t},\n" +
-            "\t\"questions\": {\n" +
-            "\t\t\"liDataSource\": \"messages\",\n" +
-            "\t\t\"whereClauses\": [{\n" +
-            "\t\t\t\"clause\": \"equals\",\n" +
-            "\t\t\t\"key\": \"author.id\",\n" +
-            "\t\t\t\"value\": \"'##'\",\n" +
-            "\t\t\t\"operator\": \"and\"\n" +
-            "\t\t}, {\n" +
-            "\t\t\t\"clause\": \"equals\",\n" +
-            "\t\t\t\"key\": \"depth\",\n" +
-            "\t\t\t\"value\": \"&&\",\n" +
-            "\t\t\t\"operator\": \"and\"\n" +
-            "\t\t}],\n" +
-            "\t\t\"ordering\": {\n" +
-            "\t\t\t\"key\": \"conversation.last_post_time\",\n" +
-            "\t\t\t\"type\": \"desc\"\n" +
-            "\t\t}\n" +
-            "\t},\n" +
-            "\t\"category\": {\n" +
-            "\t\t\"liDataSource\": \"nodes\",\n" +
-            "\t\t\"whereClauses\": [{\n" +
-            "\t\t\t\"clause\": \"equals\",\n" +
-            "\t\t\t\"key\": \"node_type\",\n" +
-            "\t\t\t\"value\": \"'category'\",\n" +
-            "\t\t\t\"operator\": \"or\"\n" +
-            "\t\t}]\n" +
-            "\t},\n" +
-            "\t\"article_browse\": {\n" +
-            "\t\t\"liDataSource\": \"messages\",\n" +
-            "\t\t\"whereClauses\": [{\n" +
-            "\t\t\t\"clause\": \"equals\",\n" +
-            "\t\t\t\"key\": \"board.id\",\n" +
-            "\t\t\t\"value\": \"'##'\",\n" +
-            "\t\t\t\"operator\": \"AND\"\n" +
-            "\t\t}, {\n" +
-            "\t\t\t\"clause\": \"equals\",\n" +
-            "\t\t\t\"key\": \"depth\",\n" +
-            "\t\t\t\"value\": \"&&\",\n" +
-            "\t\t\t\"operator\": \"or\"\n" +
-            "\t\t}],\n" +
-            "\t\t\"ordering\": {\n" +
-            "\t\t\t\"key\": \"conversation.last_post_time\",\n" +
-            "\t\t\t\"type\": \"desc\"\n" +
-            "\t\t},\n" +
-            "\t\t\"limit\": \"25\"\n" +
-            "\t},\n" +
-            "\t\"message\": {\n" +
-            "\t\t\"liDataSource\": \"messages\",\n" +
-            "\t\t\"whereClauses\": [{\n" +
-            "\t\t\t\"clause\": \"equals\",\n" +
-            "\t\t\t\"key\": \"id\",\n" +
-            "\t\t\t\"value\": \"'##'\",\n" +
-            "\t\t\t\"operator\": \"AND\"\n" +
-            "\t\t}]\n" +
-            "\t},\n" +
-            "\t\"user\": {\n" +
-            "\t\t\"liDataSource\": \"users\",\n" +
-            "\t\t\"whereClauses\": [{\n" +
-            "\t\t\t\"clause\": \"equals\",\n" +
-            "\t\t\t\"key\": \"id\",\n" +
-            "\t\t\t\"value\": \"'##'\",\n" +
-            "\t\t\t\"operator\": \"or\"\n" +
-            "\t\t}]\n" +
-            "\t},\n" +
-            "\t\"messages_by_ids\": {\n" +
-            "\t\t\"liDataSource\": \"messages\",\n" +
-            "\t\t\"whereClauses\": [{\n" +
-            "\t\t\t\"clause\": \"in\",\n" +
-            "\t\t\t\"key\": \"id\",\n" +
-            "\t\t\t\"value\": \"(##)\",\n" +
-            "\t\t\t\"operator\": \"or\"\n" +
-            "\t\t}]\n" +
-            "\t},\n" +
-            "\t\"floated_message\": {\n" +
-            "\t\t\"liDataSource\": \"floated_message\",\n" +
-            "\t\t\"whereClauses\": [{\n" +
-            "\t\t\t\"clause\": \"equals\",\n" +
-            "\t\t\t\"key\": \"message.board.id\",\n" +
-            "\t\t\t\"value\": \"'##'\",\n" +
-            "\t\t\t\"operator\": \"AND\"\n" +
-            "\t\t}, {\n" +
-            "\t\t\t\"clause\": \"equals\",\n" +
-            "\t\t\t\"key\": \"scope\",\n" +
-            "\t\t\t\"value\": \"'&&'\",\n" +
-            "\t\t\t\"operator\": \"or\"\n" +
-            "\t\t}]\n" +
-            "\t},\n" +
-            "\t\"app_sdk_setting\": {\n" +
-            "\t\t\"liDataSource\": \"app_sdk_settings\",\n" +
-            "\t\t\"whereClauses\": [{\n" +
-            "\t\t\t\"clause\": \"equals\",\n" +
-            "\t\t\t\"key\": \"client_id\",\n" +
-            "\t\t\t\"value\": \"'##'\",\n" +
-            "\t\t\t\"operator\": \"or\"\n" +
-            "\t\t}]\n" +
-            "\t}\n" +
+            "  \"article\": {\n" +
+            "    \"liDataSource\": \"messages\",\n" +
+            "    \"whereClauses\": [\n" +
+            "      {\n" +
+            "        \"clause\": \"in\",\n" +
+            "        \"key\": \"conversation.style\",\n" +
+            "        \"value\": \"('forum', 'blog')\",\n" +
+            "        \"operator\": \"AND\"\n" +
+            "      },\n" +
+            "      {\n" +
+            "        \"clause\": \"equals\",\n" +
+            "        \"key\": \"depth\",\n" +
+            "        \"value\": \"##\",\n" +
+            "        \"operator\": \"or\"\n" +
+            "      }\n" +
+            "    ],\n" +
+            "    \"ordering\": {\n" +
+            "      \"key\": \"conversation.last_post_time\",\n" +
+            "      \"type\": \"desc\"\n" +
+            "    },\n" +
+            "    \"limit\": \"50\"\n" +
+            "  },\n" +
+            "  \"test\": {\n" +
+            "    \"liDataSource\": \"test\",\n" +
+            "    \"whereClauses\": [\n" +
+            "      {\n" +
+            "        \"clause\": \"equals\",\n" +
+            "        \"key\": \"target.type\",\n" +
+            "        \"value\": \"'test'\",\n" +
+            "        \"operator\": \"AND\"\n" +
+            "      }\n" +
+            "    ],\n" +
+            "    \"limit\": \"25\"\n" +
+            "  },\n" +
+            "  \"node\": {\n" +
+            "    \"liDataSource\": \"nodes\",\n" +
+            "    \"whereClauses\": [\n" +
+            "      {\n" +
+            "        \"clause\": \"in\",\n" +
+            "        \"key\": \"conversation_style\",\n" +
+            "        \"value\": \"('forum', 'blog')\",\n" +
+            "        \"operator\": \"AND\"\n" +
+            "      },\n" +
+            "      {\n" +
+            "        \"clause\": \"equals\",\n" +
+            "        \"key\": \"parent.id\",\n" +
+            "        \"value\": \"'##'\",\n" +
+            "        \"operator\": \"and\"\n" +
+            "      }\n" +
+            "    ],\n" +
+            "    \"limit\": \"25\"\n" +
+            "  },\n" +
+            "  \"node_depth\": {\n" +
+            "    \"liDataSource\": \"nodes\",\n" +
+            "    \"whereClauses\": [\n" +
+            "      {\n" +
+            "        \"clause\": \"in\",\n" +
+            "        \"key\": \"conversation_style\",\n" +
+            "        \"value\": \"('forum', 'blog')\",\n" +
+            "        \"operator\": \"AND\"\n" +
+            "      },\n" +
+            "      {\n" +
+            "        \"clause\": \"equals\",\n" +
+            "        \"key\": \"depth\",\n" +
+            "        \"value\": \"##\",\n" +
+            "        \"operator\": \"or\"\n" +
+            "      }\n" +
+            "    ],\n" +
+            "    \"limit\": \"25\"\n" +
+            "  },\n" +
+            "  \"search\": {\n" +
+            "    \"liDataSource\": \"messages\",\n" +
+            "    \"whereClauses\": [\n" +
+            "      {\n" +
+            "        \"clause\": \"matches\",\n" +
+            "        \"key\": \"body\",\n" +
+            "        \"value\": \"'##'\",\n" +
+            "        \"operator\": \"OR\"\n" +
+            "      },\n" +
+            "      {\n" +
+            "        \"clause\": \"matches\",\n" +
+            "        \"key\": \"subject\",\n" +
+            "        \"value\": \"'##'\",\n" +
+            "        \"operator\": \"OR\"\n" +
+            "      },\n" +
+            "      {\n" +
+            "        \"clause\": \"matches\",\n" +
+            "        \"key\": \"tags.text\",\n" +
+            "        \"value\": \"'##'\",\n" +
+            "        \"operator\": \"OR\"\n" +
+            "      },\n" +
+            "      {\n" +
+            "        \"clause\": \"matches\",\n" +
+            "        \"key\": \"labels.text\",\n" +
+            "        \"value\": \"'##'\",\n" +
+            "        \"operator\": \"AND\"\n" +
+            "      },\n" +
+            "      {\n" +
+            "        \"clause\": \"in\",\n" +
+            "        \"key\": \"conversation.style\",\n" +
+            "        \"value\": \"('forum', 'blog')\",\n" +
+            "        \"operator\": \"OR\"\n" +
+            "      },\n" +
+            "      {\n" +
+            "        \"clause\": \"equals\",\n" +
+            "        \"key\": \"depth\",\n" +
+            "        \"value\": \"0\",\n" +
+            "        \"operator\": \"and\"\n" +
+            "      }\n" +
+            "    ],\n" +
+            "    \"ordering\": {\n" +
+            "      \"key\": \"conversation.last_post_time\",\n" +
+            "      \"type\": \"desc\"\n" +
+            "    },\n" +
+            "    \"limit\": \"25\"\n" +
+            "  },\n" +
+            "  \"subscription\": {\n" +
+            "    \"liDataSource\": \"subscriptions\",\n" +
+            "    \"whereClauses\": [\n" +
+            "      {\n" +
+            "        \"clause\": \"equals\",\n" +
+            "        \"key\": \"target.type\",\n" +
+            "        \"value\": \"'message'\",\n" +
+            "        \"operator\": \"AND\"\n" +
+            "      }\n" +
+            "    ],\n" +
+            "    \"limit\": \"25\"\n" +
+            "  },\n" +
+            "  \"message_children\": {\n" +
+            "    \"liDataSource\": \"messages\",\n" +
+            "    \"whereClauses\": [\n" +
+            "      {\n" +
+            "        \"clause\": \"equals\",\n" +
+            "        \"key\": \"topic.id\",\n" +
+            "        \"value\": \"'##'\",\n" +
+            "        \"operator\": \"or\"\n" +
+            "      }\n" +
+            "    ],\n" +
+            "    \"ordering\": {\n" +
+            "      \"key\": \"post_time\",\n" +
+            "      \"type\": \"asc\"\n" +
+            "    }\n" +
+            "  },\n" +
+            "  \"questions\": {\n" +
+            "    \"liDataSource\": \"messages\",\n" +
+            "    \"whereClauses\": [\n" +
+            "      {\n" +
+            "        \"clause\": \"equals\",\n" +
+            "        \"key\": \"author.id\",\n" +
+            "        \"value\": \"'##'\",\n" +
+            "        \"operator\": \"and\"\n" +
+            "      },\n" +
+            "      {\n" +
+            "        \"clause\": \"equals\",\n" +
+            "        \"key\": \"depth\",\n" +
+            "        \"value\": \"&&\",\n" +
+            "        \"operator\": \"and\"\n" +
+            "      }\n" +
+            "    ],\n" +
+            "    \"ordering\": {\n" +
+            "      \"key\": \"conversation.last_post_time\",\n" +
+            "      \"type\": \"desc\"\n" +
+            "    }\n" +
+            "  },\n" +
+            "  \"category\": {\n" +
+            "    \"liDataSource\": \"nodes\",\n" +
+            "    \"whereClauses\": [\n" +
+            "      {\n" +
+            "        \"clause\": \"equals\",\n" +
+            "        \"key\": \"node_type\",\n" +
+            "        \"value\": \"'category'\",\n" +
+            "        \"operator\": \"or\"\n" +
+            "      }\n" +
+            "    ]\n" +
+            "  },\n" +
+            "  \"article_browse\": {\n" +
+            "    \"liDataSource\": \"messages\",\n" +
+            "    \"whereClauses\": [\n" +
+            "      {\n" +
+            "        \"clause\": \"equals\",\n" +
+            "        \"key\": \"board.id\",\n" +
+            "        \"value\": \"'##'\",\n" +
+            "        \"operator\": \"AND\"\n" +
+            "      },\n" +
+            "      {\n" +
+            "        \"clause\": \"equals\",\n" +
+            "        \"key\": \"depth\",\n" +
+            "        \"value\": \"&&\",\n" +
+            "        \"operator\": \"or\"\n" +
+            "      }\n" +
+            "    ],\n" +
+            "    \"ordering\": {\n" +
+            "      \"key\": \"conversation.last_post_time\",\n" +
+            "      \"type\": \"desc\"\n" +
+            "    },\n" +
+            "    \"limit\": \"25\"\n" +
+            "  },\n" +
+            "  \"message\": {\n" +
+            "    \"liDataSource\": \"messages\",\n" +
+            "    \"whereClauses\": [\n" +
+            "      {\n" +
+            "        \"clause\": \"equals\",\n" +
+            "        \"key\": \"id\",\n" +
+            "        \"value\": \"'##'\",\n" +
+            "        \"operator\": \"AND\"\n" +
+            "      }\n" +
+            "    ]\n" +
+            "  },\n" +
+            "  \"user\": {\n" +
+            "    \"liDataSource\": \"users\",\n" +
+            "    \"whereClauses\": [\n" +
+            "      {\n" +
+            "        \"clause\": \"equals\",\n" +
+            "        \"key\": \"id\",\n" +
+            "        \"value\": \"'##'\",\n" +
+            "        \"operator\": \"or\"\n" +
+            "      }\n" +
+            "    ]\n" +
+            "  },\n" +
+            "  \"messages_by_ids\": {\n" +
+            "    \"liDataSource\": \"messages\",\n" +
+            "    \"whereClauses\": [\n" +
+            "      {\n" +
+            "        \"clause\": \"in\",\n" +
+            "        \"key\": \"id\",\n" +
+            "        \"value\": \"(##)\",\n" +
+            "        \"operator\": \"or\"\n" +
+            "      }\n" +
+            "    ]\n" +
+            "  },\n" +
+            "  \"floated_message\": {\n" +
+            "    \"liDataSource\": \"floated_message\",\n" +
+            "    \"whereClauses\": [\n" +
+            "      {\n" +
+            "        \"clause\": \"equals\",\n" +
+            "        \"key\": \"message.board.id\",\n" +
+            "        \"value\": \"'##'\",\n" +
+            "        \"operator\": \"AND\"\n" +
+            "      },\n" +
+            "      {\n" +
+            "        \"clause\": \"equals\",\n" +
+            "        \"key\": \"scope\",\n" +
+            "        \"value\": \"'&&'\",\n" +
+            "        \"operator\": \"or\"\n" +
+            "      }\n" +
+            "    ]\n" +
+            "  },\n" +
+            "  \"app_sdk_setting\": {\n" +
+            "    \"liDataSource\": \"app_sdk_settings\",\n" +
+            "    \"whereClauses\": [\n" +
+            "      {\n" +
+            "        \"clause\": \"equals\",\n" +
+            "        \"key\": \"client_id\",\n" +
+            "        \"value\": \"'##'\",\n" +
+            "        \"operator\": \"or\"\n" +
+            "      }\n" +
+            "    ]\n" +
+            "  }\n" +
             "}";
 
     public static LiAppCredentials getTestAppCredentials() {
@@ -292,14 +320,50 @@ public class TestHelper {
                 .build();
     }
 
-    public static LiAppCredentials getTestAppSSOCredentials() {
-        return new LiAppCredentials.Builder()
-                .setClientName(TEST_CLIENT_NAME)
-                .setClientKey(TEST_CLIENT_ID)
-                .setClientSecret(TEST_CLIENT_SECRET)
-                .setCommunityUri(TEST_COMMUNITY_URL)
-                .setApiGatewayUri(TEST_API_GATEWAY_HOST)
-                .setTenantId(TEST_TENANT_ID)
-                .build();
+    public static Context createMockContext() {
+
+        final Map<String, String> map = new HashMap<>();
+
+        final SharedPreferences.Editor editor = mock(SharedPreferences.Editor.class);
+        when(editor.putString(anyString(), anyString())).thenReturn(editor);
+        when(editor.putString(anyString(), anyString())).then(new Answer<SharedPreferences.Editor>() {
+            @Override
+            public SharedPreferences.Editor answer(InvocationOnMock invocation) throws Throwable {
+                String key = invocation.getArgumentAt(0, String.class);
+                String value = invocation.getArgumentAt(1, String.class);
+                map.put(key, value);
+                return editor;
+            }
+        });
+        when(editor.remove(anyString())).then(new Answer<SharedPreferences.Editor>() {
+            @Override
+            public SharedPreferences.Editor answer(InvocationOnMock invocation) throws Throwable {
+                String key = invocation.getArgumentAt(0, String.class);
+                map.remove(key);
+                return editor;
+            }
+        });
+
+        SharedPreferences preferences = mock(SharedPreferences.class);
+        when(preferences.getString(anyString(), anyString())).then(new Answer<String>() {
+            @Override
+            public String answer(InvocationOnMock invocation) throws Throwable {
+                String key = invocation.getArgumentAt(0, String.class);
+                return map.get(key);
+            }
+        });
+        when(preferences.edit()).thenReturn(editor);
+
+        InputStream inputStream = new ByteArrayInputStream(DEFAULT_QUERY_SETTINGS.getBytes(StandardCharsets.UTF_8));
+
+        Resources resource = mock(Resources.class);
+        when(resource.getBoolean(anyInt())).thenReturn(true);
+        when(resource.openRawResource(anyInt())).thenReturn(inputStream);
+
+        Context context = mock(Context.class);
+        when(context.getSharedPreferences(anyString(), anyInt())).thenReturn(preferences);
+        when(context.getResources()).thenReturn(resource);
+
+        return context;
     }
 }

--- a/li-android-sdk-core/src/test/java/lithium/community/android/sdk/manager/LiAuthManagerTest.java
+++ b/li-android-sdk-core/src/test/java/lithium/community/android/sdk/manager/LiAuthManagerTest.java
@@ -16,13 +16,13 @@
 
 package lithium.community.android.sdk.manager;
 
-import android.app.Activity;
+import android.content.Context;
 import android.content.SharedPreferences;
-import android.content.res.Resources;
 
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -34,9 +34,8 @@ import lithium.community.android.sdk.model.LiBaseModelImpl;
 import lithium.community.android.sdk.model.helpers.LiAvatar;
 import lithium.community.android.sdk.model.helpers.LiImage;
 import lithium.community.android.sdk.model.response.LiUser;
+import lithium.community.android.sdk.utils.LiCoreSDKConstants;
 
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -45,31 +44,17 @@ import static org.mockito.Mockito.when;
  */
 
 @RunWith(PowerMockRunner.class)
+@PowerMockIgnore({"javax.crypto.*"})
 @PrepareForTest({LiSDKManager.class, SharedPreferences.class})
 public class LiAuthManagerTest {
 
-    //
-    public static final String CLIENT_ID = "clientId";
-    public static final String CLIENT_SECRET = "clientSecret";
-    public static final String REFRESH = "refresh";
-    public static final String REFRESH_TOKEN = "refresh_token";
-    public static final String ACCESSTOKEN = "ACCESSTOKEN";
-    public static final String USER_ID = "UserId";
-    public static final String TOKEN_TYPE_BEARER = "TokenTypeBearer";
+    public static final String ACCESS_TOKEN = "ACCESS_TOKEN";
     public static final String NEW_REFRESH_TOKEN = "NewRefreshToken";
-    public static final String LITHIUM_USER_ID = "LithiumUserId";
-    public static final long EXPIRES_IN = 1L;
-    public static final String AUTH_CODE = "AuthCode";
-    public static final String TENANT_ID = "TenantId";
-    public static final String API_PROXY_HOST = "ApiProxyHost";
-    public static final String STATE = "State";
-    private static final String communityUrl = "http://community.lithium.com";
-    private static final String authStateJson
-            = "{\"lastSSOAuthorizationResponse\":\"{\\\"code\\\":\\\"AuthCode\\\","
+    private static final String AUTH_STATE_JSON = "{\"lastSSOAuthorizationResponse\":\"{\\\"code\\\":\\\"AuthCode\\\","
             + "\\\"proxy-host\\\":\\\"ApiProxyHost\\\",\\\"state\\\":\\\"State\\\","
             + "\\\"tenant-id\\\":\\\"TenantId\\\",\\\"user-id\\\":\\\"UserId\\\"}\","
             + "\"mLastLiTokenResponse\":\"{\\\"lithiumUserId\\\":\\\"LithiumUserId\\\","
-            + "\\\"access_token\\\":\\\"ACCESSTOKEN\\\",\\\"refresh_token\\\":\\\"NewRefreshToken\\\","
+            + "\\\"access_token\\\":\\\"ACCESS_TOKEN\\\",\\\"refresh_token\\\":\\\"NewRefreshToken\\\","
             + "\\\"expires_in\\\":1,\\\"userId\\\":\\\"UserId\\\",\\\"token_type\\\":\\\"TokenTypeBearer\\\","
             + "\\\"expiresAt\\\":1001}\",\"refreshToken\":\"NewRefreshToken\"}";
     private static final String AVATAR_IMAGE_DESC = "avatarImageDescription";
@@ -79,54 +64,45 @@ public class LiAuthManagerTest {
     private static final String LOGIN = "login";
     private static final String HREF = "href";
     private static final String PROFILE_PAGE_URL = "profile_page_url";
-    private static final String SSO_TOKEN = "sso_token";
-    //
-    private Activity activity;
-
-    private SharedPreferences sharedPreferences;
 
 
     @Test
     public void testSetLoggedInUser() throws MalformedURLException, URISyntaxException {
-        activity = mock(Activity.class);
-        sharedPreferences = mock(SharedPreferences.class);
-        Resources resource = mock(Resources.class);
-        when(resource.getBoolean(anyInt())).thenReturn(true);
-        when(activity.getSharedPreferences(anyString(), anyInt())).thenReturn(sharedPreferences);
-        when(sharedPreferences.getString(anyString(), anyString())).thenReturn(authStateJson);
-        when(activity.getResources()).thenReturn(resource);
-        LiSDKManager.init(activity, TestHelper.getTestAppCredentials());
+        Context context = TestHelper.createMockContext();
+
+        LiSDKManager.init(context, TestHelper.getTestAppCredentials());
+        LiSecuredPrefManager.getInstance().putString(context, LiCoreSDKConstants.LI_AUTH_STATE, AUTH_STATE_JSON);
+        LiSDKManager.getInstance().restoreAuthState(context);
+
         LiUser liUser = new LiUser();
+
         LiImage avatarImage = mock(LiImage.class);
         when(avatarImage.getDescription()).thenReturn(AVATAR_IMAGE_DESC);
         liUser.setAvatarImage(avatarImage);
+
         LiAvatar liAvatar = new LiAvatar();
         liAvatar.setProfile(AVATAR_PROFILE);
         liAvatar.setMessage(AVATAR_MESSAGE);
         liUser.setAvatar(liAvatar);
+
         LiBaseModelImpl.LiString email = new LiBaseModelImpl.LiString();
         email.setValue(EMAIL);
         liUser.setEmail(email);
+
         LiBaseModelImpl.LiString login = new LiBaseModelImpl.LiString();
         login.setValue(LOGIN);
         liUser.setLogin(login);
         liUser.setHref(HREF);
         liUser.setProfilePageUrl(PROFILE_PAGE_URL);
 
-        SharedPreferences.Editor editor = mock(SharedPreferences.Editor.class);
-        when(editor.commit()).thenReturn(true);
-        when(sharedPreferences.edit()).thenReturn(editor);
-        when(sharedPreferences.edit().putString(anyString(), anyString())).thenReturn(editor);
-        LiSDKManager.getInstance().setLoggedInUser(activity, liUser);
+        LiSDKManager.getInstance().setLoggedInUser(context, liUser);
 
         Assert.assertEquals(EMAIL, LiSDKManager.getInstance().getLoggedInUser().getEmail());
         Assert.assertEquals(HREF, LiSDKManager.getInstance().getLoggedInUser().getHref());
         Assert.assertEquals(PROFILE_PAGE_URL, LiSDKManager.getInstance().getLoggedInUser().getProfilePageUrl());
 
-        Assert.assertEquals(ACCESSTOKEN, LiSDKManager.getInstance().getNewAuthToken());
+        Assert.assertEquals(ACCESS_TOKEN, LiSDKManager.getInstance().getNewAuthToken());
         Assert.assertEquals(NEW_REFRESH_TOKEN, LiSDKManager.getInstance().getRefreshToken());
         Assert.assertTrue(LiSDKManager.getInstance().isUserLoggedIn());
-
     }
-
 }

--- a/li-android-sdk-core/src/test/java/lithium/community/android/sdk/manager/LiAuthManagerTest.java
+++ b/li-android-sdk-core/src/test/java/lithium/community/android/sdk/manager/LiAuthManagerTest.java
@@ -101,7 +101,7 @@ public class LiAuthManagerTest {
         Assert.assertEquals(HREF, LiSDKManager.getInstance().getLoggedInUser().getHref());
         Assert.assertEquals(PROFILE_PAGE_URL, LiSDKManager.getInstance().getLoggedInUser().getProfilePageUrl());
 
-        Assert.assertEquals(ACCESS_TOKEN, LiSDKManager.getInstance().getNewAuthToken());
+        Assert.assertEquals(ACCESS_TOKEN, LiSDKManager.getInstance().getAuthToken());
         Assert.assertEquals(NEW_REFRESH_TOKEN, LiSDKManager.getInstance().getRefreshToken());
         Assert.assertTrue(LiSDKManager.getInstance().isUserLoggedIn());
     }

--- a/li-android-sdk-core/src/test/java/lithium/community/android/sdk/manager/LiAuthStateTest.java
+++ b/li-android-sdk-core/src/test/java/lithium/community/android/sdk/manager/LiAuthStateTest.java
@@ -120,12 +120,12 @@ public class LiAuthStateTest {
                 + "\\\"access_token\\\":\\\"ACCESSTOKEN\\\",\\\"refresh_token\\\":\\\"NewRefreshToken\\\","
                 + "\\\"expires_in\\\":1,\\\"userId\\\":\\\"UserId\\\","
                 + "\\\"token_type\\\":\\\"TokenTypeBearer\\\",\\\"expiresAt\\\":1001}\","
-                + "\"refreshToken\":\"NewRefreshToken\"}", liAuthState.jsonSerializeString());
+                + "\"refreshToken\":\"NewRefreshToken\"}", liAuthState.toJsonString());
     }
 
     @Test
     public void testJsonDeserialize() throws JSONException {
-        LiAuthState liAuthState = LiAuthState.jsonDeserialize("{\"mLastTokenResponse\":{\"access_token\":\"accessToken\",\"request\":{\"clientId\":\"clientId\","
+        LiAuthState liAuthState = LiAuthState.deserialize("{\"mLastTokenResponse\":{\"access_token\":\"accessToken\",\"request\":{\"clientId\":\"clientId\","
                 + "\"configuration\":{\"authorizationEndpoint\":\"http:\\/\\/localhost:8080\"},"
                 + "\"additionalParameters\":{},\"client_secret\":\"clientSecret\","
                 + "\"grantType\":\"refresh_token\",\"refreshToken\":\"referesh\"},"

--- a/li-android-sdk-core/src/test/java/lithium/community/android/sdk/manager/LiAuthStateTest.java
+++ b/li-android-sdk-core/src/test/java/lithium/community/android/sdk/manager/LiAuthStateTest.java
@@ -44,7 +44,7 @@ import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.mock;
 
 /**
- * Created by kunal.shrivastava on 12/2/16.
+ * @author kunal.shrivastava
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({LiSystemClock.class, LiAuthState.class})
@@ -54,16 +54,17 @@ public class LiAuthStateTest {
     public static final String CLIENT_SECRET = "clientSecret";
     public static final String REFRESH = "refresh";
     public static final String REFRESH_TOKEN = "refresh_token";
-    public static final String ACCESSTOKEN = "ACCESSTOKEN";
+    public static final String ACCESS_TOKEN = "ACCESSTOKEN";
     public static final String USER_ID = "UserId";
     public static final String TOKEN_TYPE_BEARER = "TokenTypeBearer";
     public static final String NEW_REFRESH_TOKEN = "NewRefreshToken";
     public static final String LITHIUM_USER_ID = "LithiumUserId";
-    public static final long EXPIRES_IN = 1L;
     public static final String AUTH_CODE = "AuthCode";
     public static final String TENANT_ID = "TenantId";
     public static final String API_PROXY_HOST = "ApiProxyHost";
     public static final String STATE = "State";
+    public static final long EXPIRES_IN = 1L;
+
     @Rule
     public ExpectedException thrown = ExpectedException.none();
 
@@ -72,148 +73,12 @@ public class LiAuthStateTest {
 
     @Before
     public void setUp() throws IllegalAccessException {
-        // Mockito has a very convenient way to inject mocks by using the @Mock annotation. To
-        // inject the mocks in the test the initMocks method needs to be called.
         MockitoAnnotations.initMocks(this);
-        //systemClock= Mockito.mock(LiSystemClock.class);
         Field field = PowerMockito.field(LiSystemClock.class, "INSTANCE");
         mock = mock(LiSystemClock.class);
         field.set(LiSystemClock.class, mock);
         when(mock.getCurrentTimeMillis()).thenReturn(1L);
-
     }
-
-//    @Test
-//    public void testUpdateForIllegalArgumentException() {
-//        thrown.expect(IllegalArgumentException.class);
-//        LiAuthState authState = new LiAuthState();
-//        AuthorizationResponse authorizationResponse = null;
-//        LiAuthorizationException authorizationException = null;
-//        authState.update(authorizationResponse, authorizationException);
-//    }
-
-//    @Test
-//    public void testUpdateForAuthExceptionNotNull() throws Exception {
-//        LiAuthState authState = new LiAuthState();
-//        AuthorizationResponse authorizationResponse = null;
-//        LiAuthorizationException authorizationException = new LiAuthorizationException(1, 1, null, null, null, null);
-//        authState.update(authorizationResponse, authorizationException);
-//        Assert.assertEquals(null, authState.getAccessToken());
-//    }
-//
-//    @Test
-//    public void testUpdateForAuthResponseNotNull() throws Exception {
-//        LiAuthState authState = new LiAuthState();
-//        AuthorizationRequest authorizationRequest = PowerMockito.mock(AuthorizationRequest.class);
-//        HashMap<String, String> set = new HashMap<String, String>();
-//        set.put("proxy-host", "proxy-host");
-//        set.put("tenant-id", "tenant-id");
-//        AuthorizationResponse authorizationResponse = new AuthorizationResponse.Builder(authorizationRequest)
-// .setScope("test").setAdditionalParameters(set).build();
-//        LiAuthorizationException authorizationException = null;
-//        authState.update(authorizationResponse, authorizationException);
-//        Assert.assertEquals(null, authState.getAccessToken());
-//    }
-//
-//    @Test
-//    public void testGetAccessTokenExpirationTimeForNullAuthException() throws Exception {
-//        LiAuthState authState = new LiAuthState();
-//        TokenRequest tokenRequest = PowerMockito.mock(TokenRequest.class);
-//        HashMap<String, String> set = new HashMap<String, String>();
-//        set.put("proxy-host", "proxy-host");
-//        set.put("tenant-id", "tenant-id");
-//        TokenResponse tokenResponse = new TokenResponse.Builder(tokenRequest).setScope("test")
-// .setAdditionalParameters(set).build();
-//        LiAuthorizationException authorizationException = null;
-//        authState.update(tokenResponse, authorizationException);
-//        Assert.assertEquals(null, authState.getAccessTokenExpirationTime());
-//    }
-//
-//    @Test
-//    public void testGetAccessTokenExpirationTimeForNotNullAuthException() throws Exception {
-//        LiAuthState authState = new LiAuthState();
-//        TokenResponse tokenResponse = null;
-//        LiAuthorizationException authorizationException = new LiAuthorizationException(1, 1, null, null, null, null);
-//        authState.update(tokenResponse, authorizationException);
-//        Assert.assertEquals(null, authState.getAccessTokenExpirationTime());
-//    }
-//
-//    @Test
-//    public void testSetBadToken() {
-//        LiAuthState authState = new LiAuthState();
-//        AuthorizationRequest authorizationRequest = PowerMockito.mock(AuthorizationRequest.class);
-//        HashMap<String, String> set = new HashMap<String, String>();
-//        set.put("proxy-host", "proxy-host");
-//        set.put("tenant-id", "tenant-id");
-//        AuthorizationResponse authorizationResponse = new AuthorizationResponse.Builder(authorizationRequest)
-// .setScope("test").setAdditionalParameters(set).build();
-//        LiAuthorizationException authorizationException = null;
-//        authState.update(authorizationResponse, authorizationException);
-//        authState.setBadToken();
-//        AuthorizationResponse temp = authState.getLastAuthorizationResponse();
-//        Assert.assertEquals("qweertyuioplkjhgfd", temp.accessToken);
-//    }
-//
-//    @Test
-//    public void testGetRefreshToken() {
-//        LiAuthState authState = new LiAuthState();
-//        TokenRequest tokenRequest = PowerMockito.mock(TokenRequest.class);
-//        HashMap<String, String> set = new HashMap<String, String>();
-//        set.put("proxy-host", "proxy-host");
-//        set.put("tenant-id", "tenant-id");
-//        TokenResponse tokenResponse = new TokenResponse.Builder(tokenRequest).setScope("test")
-// .setAdditionalParameters(set).setRefreshToken("refresh").build();
-//        LiAuthorizationException authorizationException = null;
-//        authState.update(tokenResponse, authorizationException);
-//        Assert.assertEquals("refresh", authState.getRefreshToken());
-//    }
-//
-//    @Test
-//    public void testGetScope() {
-//        LiAuthState authState = new LiAuthState();
-//        TokenRequest tokenRequest = PowerMockito.mock(TokenRequest.class);
-//        HashMap<String, String> set = new HashMap<String, String>();
-//        set.put("proxy-host", "proxy-host");
-//        set.put("tenant-id", "tenant-id");
-//        TokenResponse tokenResponse = new TokenResponse.Builder(tokenRequest).setScope("test")
-// .setAdditionalParameters(set).setRefreshToken("refresh").build();
-//        LiAuthorizationException authorizationException = null;
-//        authState.update(tokenResponse, authorizationException);
-//        Assert.assertEquals("test", authState.getScope());
-//    }
-//
-//    @Test
-//    public void testGetScopeSet() {
-//        LiAuthState authState = new LiAuthState();
-//        TokenRequest tokenRequest = PowerMockito.mock(TokenRequest.class);
-//        TokenResponse tokenResponse = new TokenResponse.Builder(tokenRequest).setScope("test scope")
-// .setRefreshToken("refresh").build();
-//        LiAuthorizationException authorizationException = null;
-//        authState.update(tokenResponse, authorizationException);
-//        Assert.assertEquals("[test, scope]", authState.getScopeSet().toString());
-//    }
-//
-//    @Test
-//    public void testGetLastTokenReponse() {
-//        LiAuthState authState = new LiAuthState();
-//        TokenRequest tokenRequest = PowerMockito.mock(TokenRequest.class);
-//        TokenResponse tokenResponse = new TokenResponse.Builder(tokenRequest).setScope("test scope")
-// .setRefreshToken("refresh").build();
-//        LiAuthorizationException authorizationException = null;
-//        authState.update(tokenResponse, authorizationException);
-//        Assert.assertTrue(tokenResponse.equals(authState.getLastTokenResponse()));
-//    }
-//
-//    @Test
-//    public void testGetIdTokenTest() {
-//        LiAuthState authState = new LiAuthState();
-//        TokenRequest tokenRequest = PowerMockito.mock(TokenRequest.class);
-//        TokenResponse tokenResponse = new TokenResponse.Builder(tokenRequest).setRefreshToken("refresh").setIdToken
-// ("token").build();
-//        LiAuthorizationException authorizationException = null;
-//        authState.update(tokenResponse, authorizationException);
-//        Assert.assertEquals("token", authState.getIdToken());
-//    }
 
     @Test
     public void testJsonSerialize() {
@@ -236,7 +101,7 @@ public class LiAuthStateTest {
         liAuthState.update(liSsoAuthResponse);
 
         LiTokenResponse liTokenResponse = new LiTokenResponse();
-        liTokenResponse.setAccessToken(ACCESSTOKEN);
+        liTokenResponse.setAccessToken(ACCESS_TOKEN);
         liTokenResponse.setUserId(USER_ID);
         liTokenResponse.setTokenType(TOKEN_TYPE_BEARER);
         liTokenResponse.setRefreshToken(NEW_REFRESH_TOKEN);
@@ -248,28 +113,24 @@ public class LiAuthStateTest {
         liTokenResponse.setJsonString(json);
         liAuthState.update(liTokenResponse);
 
-        Assert.assertEquals(
-                "{\"lastSSOAuthorizationResponse\":\"{\\\"code\\\":\\\"AuthCode\\\","
-                        + "\\\"proxy-host\\\":\\\"ApiProxyHost\\\",\\\"state\\\":\\\"State\\\","
-                        + "\\\"tenant-id\\\":\\\"TenantId\\\",\\\"user-id\\\":\\\"UserId\\\"}\","
-                        + "\"mLastLiTokenResponse\":\"{\\\"lithiumUserId\\\":\\\"LithiumUserId\\\","
-                        + "\\\"access_token\\\":\\\"ACCESSTOKEN\\\",\\\"refresh_token\\\":\\\"NewRefreshToken\\\","
-                        + "\\\"expires_in\\\":1,\\\"userId\\\":\\\"UserId\\\","
-                        + "\\\"token_type\\\":\\\"TokenTypeBearer\\\",\\\"expiresAt\\\":1001}\","
-                        + "\"refreshToken\":\"NewRefreshToken\"}",
-                liAuthState.jsonSerializeString());
-
+        Assert.assertEquals("{\"lastSSOAuthorizationResponse\":\"{\\\"code\\\":\\\"AuthCode\\\","
+                + "\\\"proxy-host\\\":\\\"ApiProxyHost\\\",\\\"state\\\":\\\"State\\\","
+                + "\\\"tenant-id\\\":\\\"TenantId\\\",\\\"user-id\\\":\\\"UserId\\\"}\","
+                + "\"mLastLiTokenResponse\":\"{\\\"lithiumUserId\\\":\\\"LithiumUserId\\\","
+                + "\\\"access_token\\\":\\\"ACCESSTOKEN\\\",\\\"refresh_token\\\":\\\"NewRefreshToken\\\","
+                + "\\\"expires_in\\\":1,\\\"userId\\\":\\\"UserId\\\","
+                + "\\\"token_type\\\":\\\"TokenTypeBearer\\\",\\\"expiresAt\\\":1001}\","
+                + "\"refreshToken\":\"NewRefreshToken\"}", liAuthState.jsonSerializeString());
     }
 
     @Test
     public void testJsonDeserialize() throws JSONException {
-        LiAuthState liAuthState = LiAuthState.jsonDeserialize(
-                "{\"mLastTokenResponse\":{\"access_token\":\"accessToken\",\"request\":{\"clientId\":\"clientId\","
-                        + "\"configuration\":{\"authorizationEndpoint\":\"http:\\/\\/localhost:8080\"},"
-                        + "\"additionalParameters\":{},\"client_secret\":\"clientSecret\","
-                        + "\"grantType\":\"refresh_token\",\"refreshToken\":\"referesh\"},"
-                        + "\"refresh_token\":\"refresh\",\"id_token\":\"token\",\"additionalParameters\":{},"
-                        + "\"token_type\":\"tokenType\"},\"refreshToken\":\"refresh\"}");
+        LiAuthState liAuthState = LiAuthState.jsonDeserialize("{\"mLastTokenResponse\":{\"access_token\":\"accessToken\",\"request\":{\"clientId\":\"clientId\","
+                + "\"configuration\":{\"authorizationEndpoint\":\"http:\\/\\/localhost:8080\"},"
+                + "\"additionalParameters\":{},\"client_secret\":\"clientSecret\","
+                + "\"grantType\":\"refresh_token\",\"refreshToken\":\"referesh\"},"
+                + "\"refresh_token\":\"refresh\",\"id_token\":\"token\",\"additionalParameters\":{},"
+                + "\"token_type\":\"tokenType\"},\"refreshToken\":\"refresh\"}");
         Assert.assertEquals("refresh", liAuthState.getRefreshToken());
     }
 
@@ -281,30 +142,4 @@ public class LiAuthStateTest {
         liAuthState.setUser(liUser);
         Assert.assertEquals("1", liAuthState.getUser().getId().toString());
     }
-
-//    @Test
-//    public void testGetNeedsTokenRefresh() {
-//        LiAuthState authState = new LiAuthState();
-//        TokenRequest tokenRequest = PowerMockito.mock(TokenRequest.class);
-//        TokenResponse tokenResponse = new TokenResponse.Builder(tokenRequest).setRefreshToken("refresh").setIdToken
-// ("token").setAccessToken("token").setAccessTokenExpirationTime(1L).build();
-//        LiAuthorizationException authorizationException = null;
-//        authState.update(tokenResponse, authorizationException);
-//        LiClock clock = new LiClock() {
-//            @Override
-//            public long getCurrentTimeMillis() {
-//                return 1L;
-//            }
-//        };
-//        authState.setNeedsTokenRefresh(false);
-//        Assert.assertEquals(true, authState.getNeedsTokenRefresh(clock));
-//    }
-//
-//    @Test
-//    public void testCreateTokenRefreshRequestForException() {
-//        thrown.expect(IllegalStateException.class);
-//        LiAuthState authState = new LiAuthState();
-//        authState.createTokenRefreshRequest();
-//    }
-
 }

--- a/li-android-sdk-core/src/test/java/lithium/community/android/sdk/manager/LiClientManagerTest.java
+++ b/li-android-sdk-core/src/test/java/lithium/community/android/sdk/manager/LiClientManagerTest.java
@@ -16,9 +16,7 @@
 
 package lithium.community.android.sdk.manager;
 
-import android.app.Activity;
-import android.content.SharedPreferences;
-import android.content.res.Resources;
+import android.content.Context;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -28,6 +26,7 @@ import org.mockito.BDDMockito;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -39,72 +38,36 @@ import lithium.community.android.sdk.rest.LiBaseResponse;
 import lithium.community.android.sdk.rest.LiRestV2Request;
 import lithium.community.android.sdk.rest.LiRestv2Client;
 
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
-/*
-  Created by kunal.shrivastava on 11/31/16.
+/**
+ * @author kunal.shrivastava
  */
 @RunWith(PowerMockRunner.class)
+@PowerMockIgnore({"javax.crypto.*"})
 @PrepareForTest(LiRestv2Client.class)
 public class LiClientManagerTest {
 
-    public static final String LI_GENERIC_TYPE = "generic_get";
-    public static final String LI_SDK_SETTINGS_CLIENT_TYPE = "app_sdk_setting";
-    private static final String LI_ACCEPT_SOLUTION_TYPE = "solution_data";
-    private static final String LI_KUDO_TYPE = "kudo";
-    private static final String LI_POST_QUESTION_TYPE = "message";
-    private static final String LI_REPLY_MESSAGE_TYPE = "message";
     private static final String LI_ARTICLES_CLIENT_TYPE = "message";
-    private static final String LI_SUBSCRIPTIONS_CLIENT_TYPE = "subscription";
-    private static final String LI_BROWSE_CLIENT_TYPE = "node";
-    private static final String LI_SEARCH_CLIENT_TYPE = "message";
-    private static final String LI_MESSAGE_CHILDREN_CLIENT_TYPE = "message";
-    private static final String LI_QUESTIONS_CLIENT_TYPE = "message";
-    private static final String LI_CATEGORY_CLIENT_TYPE = "node";
     private static final String LI_ARTICLES_BROWSE_CLIENT_TYPE = "message";
-    private static final String LI_USER_DETAILS_CLIENT_TYPE = "user";
-    private static final String LI_MESSAGE_CLIENT_TYPE = "message";
     private static final String GET = "GET";
     private static final String DELETE = "DELETE";
-    private static final String POST = "POST";
     private static final String PUT = "PUT";
 
-
     @Mock
-    private Activity mContext;
-
-    private SharedPreferences mMockSharedPreferences;
-
-    private LiClientManager liClientManger;
-
-    private Resources resource;
-
+    private Context mContext;
     private LiRestv2Client liRestv2Client;
-
-    private LiSDKManager liSDKManager;
 
     @Before
     public void setUpTest() throws Exception {
-        // Mockito has a very convenient way to inject mocks by using the @Mock annotation. To
-        // inject the mocks in the test the initMocks method needs to be called.
         MockitoAnnotations.initMocks(this);
 
-        mContext = mock(Activity.class);
-        mMockSharedPreferences = mock(SharedPreferences.class);
-        resource = mock(Resources.class);
-        when(mContext.getSharedPreferences(anyString(), anyInt())).thenReturn(mMockSharedPreferences);
-        when(mMockSharedPreferences.getString(anyString(), anyString())).thenReturn("foobar");
-        when(mContext.getResources()).thenReturn(resource);
-        when(resource.getBoolean(anyInt())).thenReturn(true);
-        liSDKManager = LiSDKManager.init(mContext, TestHelper.getTestAppCredentials());
+        mContext = TestHelper.createMockContext();
+        LiSDKManager.init(mContext, TestHelper.getTestAppCredentials());
         liRestv2Client = PowerMockito.mock(LiRestv2Client.class);
         PowerMockito.mockStatic(LiRestv2Client.class);
         BDDMockito.given(LiRestv2Client.getInstance()).willReturn(liRestv2Client);
     }
-
 
     @Test
     public void testGetMessagesClient() {

--- a/li-android-sdk-core/src/test/java/lithium/community/android/sdk/manager/LiSDKManagerTest.java
+++ b/li-android-sdk-core/src/test/java/lithium/community/android/sdk/manager/LiSDKManagerTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package lithium.community.android.sdk;
+package lithium.community.android.sdk.manager;
 
 import android.content.Context;
 
@@ -32,10 +32,9 @@ import java.lang.reflect.Field;
 import java.net.URISyntaxException;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import lithium.community.android.sdk.TestHelper;
 import lithium.community.android.sdk.auth.LiAppCredentials;
 import lithium.community.android.sdk.exception.LiInitializationException;
-import lithium.community.android.sdk.manager.LiSDKManager;
-import lithium.community.android.sdk.manager.LiSecuredPrefManager;
 
 import static org.junit.Assert.assertEquals;
 

--- a/li-android-sdk-core/src/test/java/lithium/community/android/sdk/manager/LiSecuredPrefManagerTest.java
+++ b/li-android-sdk-core/src/test/java/lithium/community/android/sdk/manager/LiSecuredPrefManagerTest.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright 2018 Lithium Technologies Pvt Ltd
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package lithium.community.android.sdk.manager;
+
+import android.content.Context;
+import android.test.mock.MockContext;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+
+import java.lang.reflect.Field;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import lithium.community.android.sdk.TestHelper;
+
+/**
+ * @author adityasharat
+ */
+@PowerMockIgnore({"javax.crypto.*"})
+public class LiSecuredPrefManagerTest {
+
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private Context context;
+
+    @Before
+    public void resetSingleton() throws SecurityException, NoSuchFieldException, IllegalArgumentException, IllegalAccessException {
+        Field instance = LiSecuredPrefManager.class.getDeclaredField("instance");
+        instance.setAccessible(true);
+        instance.set(null, null);
+        Field isInitialized = LiSecuredPrefManager.class.getDeclaredField("isInitialized");
+        isInitialized.setAccessible(true);
+        isInitialized.set(null, new AtomicBoolean(false));
+        context = TestHelper.createMockContext();
+    }
+
+    @Test
+    public void initialize() throws Exception {
+        LiSecuredPrefManager.initialize("ThisIsASecretKey");
+        Assert.assertNotNull(LiSecuredPrefManager.getInstance());
+    }
+
+    @Test
+    public void initialize_null() throws Exception {
+        thrown.expect(IllegalArgumentException.class);
+        //noinspection ConstantConditions for test
+        LiSecuredPrefManager.initialize(null);
+    }
+
+    @Test
+    public void init() throws Exception {
+        MockContext context = new MockContext();
+        LiSecuredPrefManager instance = LiSecuredPrefManager.init(context);
+        Assert.assertNotNull(instance);
+    }
+
+    @Test
+    public void init_null() throws Exception {
+        thrown.expect(IllegalArgumentException.class);
+        //noinspection ConstantConditions for test
+        LiSecuredPrefManager instance = LiSecuredPrefManager.init(null);
+        Assert.assertNotNull(instance);
+    }
+
+    @Test
+    public void getString() throws Exception {
+        LiSecuredPrefManager.initialize("ThisIsASecretKey");
+        LiSecuredPrefManager instance = LiSecuredPrefManager.getInstance();
+        assert instance != null;
+        String string = instance.getString(context, "test");
+        Assert.assertNull(string);
+    }
+
+    @Test
+    public void getString_null_context() throws Exception {
+        thrown.expect(IllegalArgumentException.class);
+        LiSecuredPrefManager.initialize("ThisIsASecretKey");
+        LiSecuredPrefManager instance = LiSecuredPrefManager.getInstance();
+        assert instance != null;
+        //noinspection ConstantConditions for test
+        instance.getString(null, "test");
+    }
+
+    @Test
+    public void getString_null_key() throws Exception {
+        thrown.expect(IllegalArgumentException.class);
+        LiSecuredPrefManager.initialize("ThisIsASecretKey");
+        LiSecuredPrefManager instance = LiSecuredPrefManager.getInstance();
+        assert instance != null;
+        //noinspection ConstantConditions for test
+        instance.getString(context, null);
+    }
+
+    @Test
+    public void getString_null_context_null_key() throws Exception {
+        thrown.expect(IllegalArgumentException.class);
+        LiSecuredPrefManager.initialize("ThisIsASecretKey");
+        LiSecuredPrefManager instance = LiSecuredPrefManager.getInstance();
+        assert instance != null;
+        //noinspection ConstantConditions for test
+        instance.getString(null, null);
+    }
+
+    @Test
+    public void putString_getString() throws Exception {
+        LiSecuredPrefManager.initialize("ThisIsASecretKey");
+        LiSecuredPrefManager instance = LiSecuredPrefManager.getInstance();
+        assert instance != null;
+        String key = "test";
+        String value = "value";
+        instance.putString(context, key, value);
+        String string = instance.getString(context, key);
+        Assert.assertEquals(string, value);
+    }
+
+    @Test
+    public void remove() throws Exception {
+        LiSecuredPrefManager.initialize("ThisIsASecretKey");
+        LiSecuredPrefManager instance = LiSecuredPrefManager.getInstance();
+        assert instance != null;
+        String key = "test";
+        String value = "value";
+        instance.putString(context, key, value);
+        instance.remove(context, key);
+        String string = instance.getString(context, key);
+        Assert.assertNull(string);
+    }
+
+    @Test
+    public void remove_null_context() throws Exception {
+        thrown.expect(IllegalArgumentException.class);
+        LiSecuredPrefManager.initialize("ThisIsASecretKey");
+        LiSecuredPrefManager instance = LiSecuredPrefManager.getInstance();
+        assert instance != null;
+        String key = "test";
+        String value = "value";
+        instance.putString(context, key, value);
+        //noinspection ConstantConditions for test
+        instance.remove(null, key);
+    }
+
+    @Test
+    public void remove_null_key() throws Exception {
+        thrown.expect(IllegalArgumentException.class);
+        LiSecuredPrefManager.initialize("ThisIsASecretKey");
+        LiSecuredPrefManager instance = LiSecuredPrefManager.getInstance();
+        assert instance != null;
+        String key = "test";
+        String value = "value";
+        instance.putString(context, key, value);
+        //noinspection ConstantConditions for test
+        instance.remove(context, null);
+    }
+
+    @Test
+    public void remove_null_context_null_key() throws Exception {
+        thrown.expect(IllegalArgumentException.class);
+        LiSecuredPrefManager.initialize("ThisIsASecretKey");
+        LiSecuredPrefManager instance = LiSecuredPrefManager.getInstance();
+        assert instance != null;
+        String key = "test";
+        String value = "value";
+        instance.putString(context, key, value);
+        //noinspection ConstantConditions for test
+        instance.remove(null, null);
+    }
+
+    @Test
+    public void encrypt() throws Exception {
+    }
+
+    @Test
+    public void decrypt() throws Exception {
+    }
+
+}

--- a/li-android-sdk-core/src/test/java/lithium/community/android/sdk/model/response/LiMessageTest.java
+++ b/li-android-sdk-core/src/test/java/lithium/community/android/sdk/model/response/LiMessageTest.java
@@ -24,7 +24,10 @@ import org.junit.Test;
 
 import java.util.List;
 
+import lithium.community.android.sdk.TestHelper;
+import lithium.community.android.sdk.exception.LiInitializationException;
 import lithium.community.android.sdk.exception.LiRestResponseException;
+import lithium.community.android.sdk.manager.LiSDKManager;
 import lithium.community.android.sdk.model.LiBaseModel;
 import lithium.community.android.sdk.rest.LiBaseResponse;
 import lithium.community.android.sdk.rest.LiRestv2Client;
@@ -35,10 +38,12 @@ import static org.junit.Assert.fail;
 
 
 public class LiMessageTest {
+
     Gson gson;
 
     @Before
-    public void setUp() throws LiRestResponseException {
+    public void setUp() throws LiRestResponseException, LiInitializationException {
+        LiSDKManager.initialize(TestHelper.createMockContext(), TestHelper.getTestAppCredentials());
         gson = LiRestv2Client.getInstance().getGson();
     }
 

--- a/li-android-sdk-core/src/test/java/lithium/community/android/sdk/rest/LiAuthRestClientTest.java
+++ b/li-android-sdk-core/src/test/java/lithium/community/android/sdk/rest/LiAuthRestClientTest.java
@@ -16,9 +16,7 @@
 
 package lithium.community.android.sdk.rest;
 
-import android.app.Activity;
-import android.content.SharedPreferences;
-import android.content.res.Resources;
+import android.content.Context;
 import android.net.Uri;
 
 import org.junit.Assert;
@@ -26,10 +24,10 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -49,8 +47,6 @@ import okhttp3.Response;
 import okhttp3.ResponseBody;
 
 import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.isA;
 import static org.powermock.api.mockito.PowerMockito.doAnswer;
 import static org.powermock.api.mockito.PowerMockito.doReturn;
@@ -63,6 +59,7 @@ import static org.powermock.api.mockito.PowerMockito.when;
  */
 
 @RunWith(PowerMockRunner.class)
+@PowerMockIgnore({"javax.crypto.*"})
 @PrepareForTest({LiAuthRestClient.class, OkHttpClient.class, Response.class, ResponseBody.class})
 public class LiAuthRestClientTest {
     public static final String CLIENT_ID = "clientId";
@@ -76,26 +73,15 @@ public class LiAuthRestClientTest {
     public static final String GRANT_TYPE = "grantType";
     public static final String CLIENT_SECRET = "clientSecret";
     public static final String REFRESH_TOKEN = "refreshToken";
+
     @Mock
-    private Activity mContext;
-    private SharedPreferences mMockSharedPreferences;
-    private Resources resource;
-    private LiSDKManager liSDKManager;
+    private Context mContext;
 
     @Before
     public void setUpTest() throws Exception {
-        // Mockito has a very convenient way to inject mocks by using the @Mock annotation. To
-        // inject the mocks in the test the initMocks method needs to be called.
         MockitoAnnotations.initMocks(this);
-
-        mContext = Mockito.mock(Activity.class);
-        mMockSharedPreferences = Mockito.mock(SharedPreferences.class);
-        resource = Mockito.mock(Resources.class);
-        Mockito.when(mContext.getSharedPreferences(anyString(), anyInt())).thenReturn(mMockSharedPreferences);
-        Mockito.when(mMockSharedPreferences.getString(anyString(), anyString())).thenReturn("foobar");
-        Mockito.when(mContext.getResources()).thenReturn(resource);
-        Mockito.when(resource.getBoolean(anyInt())).thenReturn(true);
-        liSDKManager = LiSDKManager.init(mContext, TestHelper.getTestAppCredentials());
+        mContext = TestHelper.createMockContext();
+        LiSDKManager.init(mContext, TestHelper.getTestAppCredentials());
     }
 
 

--- a/li-android-sdk-core/src/test/java/lithium/community/android/sdk/rest/LiRestv2ClientTest.java
+++ b/li-android-sdk-core/src/test/java/lithium/community/android/sdk/rest/LiRestv2ClientTest.java
@@ -16,9 +16,7 @@
 
 package lithium.community.android.sdk.rest;
 
-import android.app.Activity;
-import android.content.SharedPreferences;
-import android.content.res.Resources;
+import android.content.Context;
 
 import org.junit.Assert;
 import org.junit.Test;
@@ -45,8 +43,6 @@ import lithium.community.android.sdk.utils.LiCoreSDKUtils;
 import okhttp3.Request;
 import okhttp3.internal.platform.Platform;
 
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -63,30 +59,14 @@ import static org.powermock.api.mockito.PowerMockito.doReturn;
 })
 public class LiRestv2ClientTest {
 
-    private static String liql = "select * from messages";
-    private Activity context;
-
-    @Test
-    public void testGetInstance() {
-//        LiRestv2Client liRestv2Client = LiRestv2Client.getInstance();
-//        Assert.assertTrue(liRestv2Client.getGson() != null);
-    }
-
     @Test
     public void testValidateResponse() throws Exception {
-        context = Mockito.mock(Activity.class);
-        Resources resources = Mockito.mock(Resources.class);
-        when(context.getResources()).thenReturn(resources);
-        when(resources.openRawResource(anyInt())).thenReturn(null);
-
-        SharedPreferences preferences = Mockito.mock(SharedPreferences.class);
-        when(context.getSharedPreferences(anyString(), anyInt())).thenReturn(preferences);
-        when(preferences.getString(anyString(), anyString())).thenReturn("");
+        Context context = TestHelper.createMockContext();
 
         PowerMockito.mockStatic(LiClientManager.class);
-        LiClientManager liClientManager = PowerMockito.mock(LiClientManager.class);
-
+        PowerMockito.mock(LiClientManager.class);
         PowerMockito.mockStatic(SSLContext.class);
+
         SSLContext sslContext = PowerMockito.mock(SSLContext.class);
         when(sslContext.getInstance("SSL")).thenReturn(sslContext);
         Mockito.doNothing().when(sslContext).init(isA(KeyManager[].class), isA(TrustManager[].class), isA(SecureRandom.class));
@@ -108,6 +88,7 @@ public class LiRestv2ClientTest {
         LiRestv2Client liRestv2ClientSpy = spy(liRestv2Client);
         doReturn(liBaseResponse).when(liRestv2ClientSpy).processSync(isA(LiBaseRestRequest.class));
 
+        String liql = "select * from messages";
         LiRestV2Request liBaseRestRequest = new LiRestV2Request(context, liql, "message");
         liBaseRestRequest.addQueryParam("test");
 
@@ -117,4 +98,3 @@ public class LiRestv2ClientTest {
         PowerMockito.verifyStatic();
     }
 }
-

--- a/li-android-sdk-core/src/test/java/lithium/community/android/sdk/rest/LiRestv2ClientTest.java
+++ b/li-android-sdk-core/src/test/java/lithium/community/android/sdk/rest/LiRestv2ClientTest.java
@@ -26,6 +26,7 @@ import org.junit.runner.RunWith;
 import org.mockito.BDDMockito;
 import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -56,6 +57,7 @@ import static org.powermock.api.mockito.PowerMockito.doReturn;
  */
 
 @RunWith(PowerMockRunner.class)
+@PowerMockIgnore({"javax.crypto.*"})
 @PrepareForTest({LiClientManager.class, LiRestv2Client.class, LiRestClient.class, SSLContext.class, Platform.class,
         Request.class, LiCoreSDKUtils.class
 })

--- a/li-android-sdk-core/src/test/java/lithium/community/android/sdk/utils/LiQueryBuilderTest.java
+++ b/li-android-sdk-core/src/test/java/lithium/community/android/sdk/utils/LiQueryBuilderTest.java
@@ -16,19 +16,13 @@
 
 package lithium.community.android.sdk.utils;
 
-import android.app.Activity;
-import android.content.SharedPreferences;
-import android.content.res.Resources;
-
-import com.google.gson.Gson;
-import com.google.gson.JsonObject;
+import android.content.Context;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.mockito.BDDMockito;
 import org.mockito.MockitoAnnotations;
-import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
@@ -38,52 +32,27 @@ import lithium.community.android.sdk.queryutil.LiDefaultQueryHelper;
 import lithium.community.android.sdk.queryutil.LiQueryBuilder;
 
 import static junit.framework.Assert.assertEquals;
-import static org.mockito.Matchers.anyInt;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * Created by kunal.shrivastava on 10/24/16.
  */
 @RunWith(PowerMockRunner.class)
+@PowerMockIgnore({"javax.crypto.*"})
 @PrepareForTest(LiDefaultQueryHelper.class)
 public class LiQueryBuilderTest {
-    private static final String BASE_TEST_QUERY
-            = "SELECT id, body, subject, post_time, kudos.sum(weight), conversation.style FROM TEST";
+    private static final String BASE_TEST_QUERY = "SELECT id, body, subject, post_time, kudos.sum(weight), conversation.style FROM TEST";
     private static final String TEST_TYPE = "test";
     private static final String TYPE_HAVING_NO_CONFIG = "noconfig";
-    private static final String RESULTANT_TEST_QUERY
-            = "SELECT id, body, subject, post_time, kudos.sum(weight), conversation.style FROM TEST WHERE target.type"
+    private static final String RESULTANT_TEST_QUERY = "SELECT id, body, subject, post_time, kudos.sum(weight), conversation.style FROM TEST WHERE target.type"
             + " = 'test' LIMIT 25";
-    private Activity mContext;
-    private LiSDKManager liSDKManager;
-    private SharedPreferences mMockSharedPreferences;
-    private Resources resource;
-    private String defaultSettings = TestHelper.DEFAULT_QUERY_SETTINGS;
 
-    private LiDefaultQueryHelper liDefaultQueryHelper;
+    private Context mContext;
 
     @Before
     public void setUpTest() throws Exception {
         MockitoAnnotations.initMocks(this);
-        mContext = mock(Activity.class);
-        mMockSharedPreferences = mock(SharedPreferences.class);
-        resource = mock(Resources.class);
-        when(resource.getBoolean(anyInt())).thenReturn(true);
-        when(mContext.getSharedPreferences(anyString(), anyInt())).thenReturn(mMockSharedPreferences);
-        when(mMockSharedPreferences.getString(anyString(), anyString())).thenReturn("foobar");
-        when(mContext.getResources()).thenReturn(resource);
-        JsonObject jsonObject = new Gson().fromJson(defaultSettings, JsonObject.class);
-
-        liDefaultQueryHelper = mock(LiDefaultQueryHelper.class);
-        when(liDefaultQueryHelper.getDefaultSetting()).thenReturn(jsonObject);
-        PowerMockito.mockStatic(LiDefaultQueryHelper.class);
-        when(LiDefaultQueryHelper.initHelper(mContext)).thenReturn(liDefaultQueryHelper);
-        BDDMockito.given(LiDefaultQueryHelper.getInstance()).willReturn(liDefaultQueryHelper);
-
-        liSDKManager = LiSDKManager.init(mContext, TestHelper.getTestAppCredentials());
-
+        mContext = TestHelper.createMockContext();
+        LiSDKManager.init(mContext, TestHelper.getTestAppCredentials());
     }
 
     @Test


### PR DESCRIPTION
### change log

* Add `@Deprecated` annotation to all deprecated methods.
* Refactor initialization of internal components `LiSecuredPrefManager`, `LiDefaultQueryHelper`, `LiRestv2Client`
* Fix bug in `LiSecuredPrefManager`. The encryption/decryption was failing.
* Fixed all unit test which used incorrectly mock `Context` and `SharedPreference`.
* Refactored variable nameing, indentations and java docs across multiple files.
* Remove insecure SSL connection manager from OkHttpClient builder