### PR TITLE
Use the community instead of API Gateway to execute API calls

### DIFF
--- a/li-android-sdk-core/build.gradle
+++ b/li-android-sdk-core/build.gradle
@@ -27,7 +27,7 @@ properties.load(project.rootProject.file('local.properties').newDataInputStream(
 project.ext.set('groupId', 'lithium.community.android.sdk')
 project.ext.set('artifactId', 'li-android-sdk-core')
 
-project.ext.set('versionCode', 120611)
+project.ext.set('versionCode', 126001) // `major` + `minor` + `revision` + `build` (must have leading zeros up to 1000)
 project.ext.set('versionName', '1.2.6')
 
 project.ext.set('repositoryName', 'li-android-sdk')
@@ -57,11 +57,13 @@ android {
 
     buildTypes {
         buildTypes.each {
-            it.resValue "string", "li_sdk_core_version", "${project.ext.versionName}"
-            it.buildConfigField "String", "li_sdk_core_version", "\"${project.ext.versionName}\""
+            it.resValue "string", "LI_SDK_CORE_VERSION", "${project.ext.versionName}"
+            it.buildConfigField "String", "LI_SDK_CORE_VERSION", "\"${project.ext.versionName}\""
         }
 
         debug {
+            minifyEnabled false
+            debuggable true
             testCoverageEnabled true
         }
 

--- a/li-android-sdk-core/proguard-rules.pro
+++ b/li-android-sdk-core/proguard-rules.pro
@@ -26,6 +26,7 @@
 -keepattributes *
 -dontshrink
 -dontoptimize
+-dontobfuscate
 
 -assumenosideeffects class android.util.Log {
    public static boolean isLoggable(java.lang.String, int);

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/auth/LiAppCredentials.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/auth/LiAppCredentials.java
@@ -18,6 +18,7 @@ package lithium.community.android.sdk.auth;
 
 import android.net.Uri;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import lithium.community.android.sdk.utils.LiCoreSDKUtils;
 import lithium.community.android.sdk.utils.LiUriUtils;
@@ -62,9 +63,6 @@ public final class LiAppCredentials {
     private final String deviceId;
 
     @NonNull
-    private final Uri apiGatewayHost;
-
-    @NonNull
     private final Uri authorizeUri;
 
     @NonNull
@@ -76,17 +74,15 @@ public final class LiAppCredentials {
     /**
      * Default public constructor for Lia SDK Credentials.
      *
-     * @param clientName     The client name.
-     * @param clientKey      The client Id.
-     * @param clientSecret   The client secret.
-     * @param tenantId       tenant ID of the community.
-     * @param communityURL   The LIA community's URL. (scheme + host)
-     * @param apiGatewayHost API gateway host. (host)
-     * @param deviceId       A unique static identifier for this device. Suggested Firebase instance id.
+     * @param clientName   The client name.
+     * @param clientKey    The client Id.
+     * @param clientSecret The client secret.
+     * @param tenantId     tenant ID of the community.
+     * @param communityURL The LIA community's URL. (scheme + host)
+     * @param deviceId     A unique static identifier for this device. Suggested Firebase instance id.
      */
     public LiAppCredentials(@NonNull String clientName, @NonNull String clientKey, @NonNull String clientSecret,
-                            @NonNull String tenantId, @NonNull String communityURL, @NonNull String apiGatewayHost,
-                            @NonNull String deviceId) {
+                            @NonNull String tenantId, @NonNull String communityURL, @NonNull String deviceId) {
         this.clientName = LiCoreSDKUtils.checkNotNullAndNotEmpty(clientName, MessageConstants.wasEmpty("clientName"));
         this.clientKey = LiCoreSDKUtils.checkNotNullAndNotEmpty(clientKey, MessageConstants.wasEmpty("clientKey"));
         this.clientSecret = LiCoreSDKUtils.checkNotNullAndNotEmpty(clientSecret, MessageConstants.wasEmpty("clientSecret"));
@@ -95,11 +91,27 @@ public final class LiAppCredentials {
         this.communityUri = Uri.parse(LiCoreSDKUtils.checkNotNullAndNotEmpty(communityURL, MessageConstants.wasEmpty("communityURL")));
         this.deviceId = LiCoreSDKUtils.checkNotNullAndNotEmpty(deviceId, MessageConstants.wasEmpty("deviceId"));
 
-        this.apiGatewayHost = Uri.parse(LiCoreSDKUtils.checkNotNullAndNotEmpty(apiGatewayHost, MessageConstants.wasEmpty("apiGatewayHost")));
-
         this.redirectUri = buildRedirectUri(communityUri);
         this.ssoAuthorizeUri = communityURL + SSO_AUTH_END_POINT;
         this.authorizeUri = this.communityUri.buildUpon().path(OAUTH_END_POINT).build();
+    }
+
+    /**
+     * Default public constructor for Lia SDK Credentials.
+     *
+     * @param clientName     The client name.
+     * @param clientKey      The client Id.
+     * @param clientSecret   The client secret.
+     * @param tenantId       tenant ID of the community.
+     * @param communityURL   The LIA community's URL. (scheme + host)
+     * @param apiGatewayHost API gateway host. (host)
+     * @param deviceId       A unique static identifier for this device. Suggested Firebase instance id.
+     * @deprecated Use {@link #LiAppCredentials(String, String, String, String, String, String)} instead.
+     */
+    public LiAppCredentials(@NonNull String clientName, @NonNull String clientKey, @NonNull String clientSecret,
+                            @NonNull String tenantId, @NonNull String communityURL, @Deprecated @Nullable String apiGatewayHost,
+                            @NonNull String deviceId) {
+        this(clientName, clientKey, clientSecret, tenantId, communityURL, deviceId);
     }
 
     private static String buildRedirectUri(Uri communityUri) {
@@ -136,9 +148,14 @@ public final class LiAppCredentials {
         return deviceId;
     }
 
+    /**
+     * The API Gateways host address.
+     *
+     * @return The API Gateway host Uri.
+     */
     @NonNull
     public Uri getApiGatewayHost() {
-        return apiGatewayHost;
+        return getCommunityUri();
     }
 
     @NonNull
@@ -173,7 +190,7 @@ public final class LiAppCredentials {
     @Deprecated
     @NonNull
     public String getApiProxyHost() {
-        return getApiGatewayHost().toString();
+        return getCommunityUri().toString();
     }
 
     @Override
@@ -190,8 +207,7 @@ public final class LiAppCredentials {
 
         return clientName.equals(that.clientName) && tenantId.equals(that.tenantId) && clientKey.equals(that.clientKey)
                 && clientSecret.equals(that.clientSecret) && communityUri.equals(that.communityUri) && deviceId.equals(that.deviceId)
-                && apiGatewayHost.equals(that.apiGatewayHost) && authorizeUri.equals(that.authorizeUri) && redirectUri.equals(that.redirectUri)
-                && ssoAuthorizeUri.equals(that.ssoAuthorizeUri);
+                && authorizeUri.equals(that.authorizeUri) && redirectUri.equals(that.redirectUri) && ssoAuthorizeUri.equals(that.ssoAuthorizeUri);
     }
 
     @Override
@@ -202,7 +218,6 @@ public final class LiAppCredentials {
         result = 31 * result + clientSecret.hashCode();
         result = 31 * result + communityUri.hashCode();
         result = 31 * result + deviceId.hashCode();
-        result = 31 * result + apiGatewayHost.hashCode();
         result = 31 * result + authorizeUri.hashCode();
         result = 31 * result + redirectUri.hashCode();
         result = 31 * result + ssoAuthorizeUri.hashCode();
@@ -222,7 +237,6 @@ public final class LiAppCredentials {
         private String clientSecret;
         private String tenantId;
         private String communityUri;
-        private String apiGatewayUri;
 
         /**
          * Default public constructor for the builder.
@@ -297,7 +311,6 @@ public final class LiAppCredentials {
          */
         @NonNull
         public Builder setApiGatewayUri(@NonNull String apiGatewayUri) {
-            this.apiGatewayUri = apiGatewayUri;
             return this;
         }
 
@@ -310,7 +323,6 @@ public final class LiAppCredentials {
          */
         @Deprecated
         public Builder setApiProxyHost(@NonNull String apiProxyHost) {
-            this.apiGatewayUri = apiProxyHost;
             return this;
         }
 
@@ -334,7 +346,7 @@ public final class LiAppCredentials {
          */
         @NonNull
         public LiAppCredentials build() {
-            return new LiAppCredentials(clientName, clientKey, clientSecret, tenantId, communityUri, apiGatewayUri, "deviceId");
+            return new LiAppCredentials(clientName, clientKey, clientSecret, tenantId, communityUri, "deviceId");
         }
     }
 }

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/auth/LiAuthConstants.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/auth/LiAuthConstants.java
@@ -26,6 +26,6 @@ public class LiAuthConstants {
     public static final String LOGIN_RESULT = "LOGIN_RESULT";
     public static final String AUTHORIZATION = "Authorization";
     public static final String BEARER = "Bearer ";
-    public static final String API_PROXY_DEFAULT_SEARCH_BASE_PATH = "community/2.0/%s/search";
-    public static final String API_PROXY_DEFAULT_GENERIC_BASE_PATH = "community/2.0/%s/%s";
+    public static final String API_PROXY_DEFAULT_SEARCH_BASE_PATH = "%s/api/2.0/search";
+    public static final String API_PROXY_DEFAULT_GENERIC_BASE_PATH = "%s/api/2.0/%s";
 }

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/auth/LiAuthServiceImpl.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/auth/LiAuthServiceImpl.java
@@ -239,12 +239,7 @@ public class LiAuthServiceImpl implements LiAuthService {
         request.setClientSecret(credentials.getClientSecret());
         request.setGrantType("authorization_code");
         try {
-            String proxyHost;
-            if (response.getApiProxyHost() == null) {
-                proxyHost = credentials.getApiGatewayHost().toString();
-            } else {
-                proxyHost = response.getApiProxyHost();
-            }
+            String proxyHost = credentials.getApiGatewayHost().toString();
             String uri = "https://" + proxyHost + "/auth/v1/accessToken";
             request.setUri(Uri.parse(uri));
             client.accessTokenAsync(context, request, new LiAuthAsyncRequestCallback<LiBaseResponse>() {

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiAuthManager.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiAuthManager.java
@@ -263,7 +263,7 @@ class LiAuthManager {
      * @return the API gateway's host address.
      */
     public String getApiGatewayHost() {
-        return state != null && !TextUtils.isEmpty(state.getProxyHost()) ? state.getProxyHost() : credentials.getApiGatewayHost().toString();
+        return credentials.getApiGatewayHost().toString();
     }
 
     /**

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiClientManager.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiClientManager.java
@@ -84,7 +84,7 @@ import static lithium.community.android.sdk.utils.LiQueryConstant.LI_USER_DETAIL
  */
 public class LiClientManager {
 
-    private static final String API_PATH_PREFIX = "/%s/api/2.0/%s";
+    private static final String API_PATH_PREFIX = "%s/api/2.0/%s";
 
     public static LiRestv2Client getRestClient() {
         return LiRestv2Client.getInstance();

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiClientManager.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiClientManager.java
@@ -84,6 +84,8 @@ import static lithium.community.android.sdk.utils.LiQueryConstant.LI_USER_DETAIL
  */
 public class LiClientManager {
 
+    private static final String API_PATH_PREFIX = "/%s/api/2.0/%s";
+
     public static LiRestv2Client getRestClient() {
         return LiRestv2Client.getInstance();
     }
@@ -359,8 +361,8 @@ public class LiClientManager {
 
         params.validate(Client.LI_KUDO_CLIENT);
         String messageId = ((LiClientRequestParams.LiKudoClientRequestParams) params).getMessageId();
-        final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(), String.format("/community/2.0/%s/messages/%s/kudos",
-                LiSDKManager.getInstance().getTenantId(), messageId));
+        String path = String.format(API_PATH_PREFIX, LiSDKManager.getInstance().getTenantId(), String.format("messages/%s/kudos", messageId));
+        final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(), path);
 
         LiPostKudoModel liPostKudoModel = new LiPostKudoModel();
         LiMessage liMessage = new LiMessage();
@@ -402,8 +404,8 @@ public class LiClientManager {
     public static LiClient getAcceptSolutionClient(LiClientRequestParams params) throws LiRestResponseException {
         params.validate(Client.LI_ACCEPT_SOLUTION_CLIENT);
         Long messageId = ((LiClientRequestParams.LiAcceptSolutionClientRequestParams) params).getMessageId();
-        LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(),
-                String.format("/community/2.0/%s/solutions_data", LiSDKManager.getInstance().getTenantId()));
+        String path = String.format(API_PATH_PREFIX, LiSDKManager.getInstance().getTenantId(), "solutions_data");
+        LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(), path);
         LiAcceptSolutionModel liAcceptSolutionModel = new LiAcceptSolutionModel();
         liAcceptSolutionModel.setType(LiQueryConstant.LI_ACCEPT_SOLUTION_TYPE);
         liAcceptSolutionModel.setMessageid(String.valueOf(messageId));
@@ -432,8 +434,8 @@ public class LiClientManager {
         final String imageId = ((LiClientRequestParams.LiCreateMessageClientRequestParams) params).getImageId();
         final String imageName = ((LiClientRequestParams.LiCreateMessageClientRequestParams) params).getImageName();
 
-        final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(),
-                String.format("/community/2.0/%s/messages", LiSDKManager.getInstance().getTenantId()));
+        String path = String.format(API_PATH_PREFIX, LiSDKManager.getInstance().getTenantId(), "messages");
+        final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(), path);
 
         LiPostMessageModel liPostMessageModel = new LiPostMessageModel();
         LiBoard liBoard = new LiBoard();
@@ -470,8 +472,8 @@ public class LiClientManager {
         final String body = ((LiClientRequestParams.LiUpdateMessageClientRequestParams) params).getBody();
         final String messageId = ((LiClientRequestParams.LiUpdateMessageClientRequestParams) params).getMessageId();
 
-        final LiBasePutClient liBasePutClient = new LiBasePutClient(params.getContext(),
-                String.format("/community/2.0/%s/messages/%s", LiSDKManager.getInstance().getTenantId(), messageId));
+        final String path = String.format(API_PATH_PREFIX, LiSDKManager.getInstance().getTenantId(), String.format("messages/%s", messageId));
+        final LiBasePutClient liBasePutClient = new LiBasePutClient(params.getContext(), path);
         LiPostMessageModel liPostMessageModel = new LiPostMessageModel();
         liPostMessageModel.setType(LI_POST_QUESTION_TYPE);
         liPostMessageModel.setBody(body);
@@ -518,8 +520,8 @@ public class LiClientManager {
         final Long messageId = ((LiClientRequestParams.LiCreateReplyClientRequestParams) params).getMessageId();
         final String imageId = ((LiClientRequestParams.LiCreateReplyClientRequestParams) params).getImageId();
         final String imageName = ((LiClientRequestParams.LiCreateReplyClientRequestParams) params).getImageName();
-        final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(),
-                String.format("/community/2.0/%s/messages", LiSDKManager.getInstance().getTenantId()));
+        String path = String.format(API_PATH_PREFIX, LiSDKManager.getInstance().getTenantId(), "messages");
+        final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(), path);
 
         final LiReplyMessageModel liReplyMessage = new LiReplyMessageModel();
         LiMessage parent = new LiMessage();
@@ -560,8 +562,8 @@ public class LiClientManager {
         final String description = ((LiClientRequestParams.LiUploadImageClientRequestParams) params).getDescription();
         final String imageName = ((LiClientRequestParams.LiUploadImageClientRequestParams) params).getImageName();
         final String path = ((LiClientRequestParams.LiUploadImageClientRequestParams) params).getPath();
-        final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(),
-                String.format("/community/2.0/%s/images", LiSDKManager.getInstance().getTenantId()), path, imageName);
+        String urlPath = String.format(API_PATH_PREFIX, LiSDKManager.getInstance().getTenantId(), "images");
+        final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(), urlPath, path, imageName);
 
         LiUploadImageModel uploadImageModel = new LiUploadImageModel();
         uploadImageModel.setType(LiQueryConstant.LI_IMAGE_TYPE);
@@ -592,8 +594,8 @@ public class LiClientManager {
         final String messageId = ((LiClientRequestParams.LiReportAbuseClientRequestParams) params).getMessageId();
         final String userId = ((LiClientRequestParams.LiReportAbuseClientRequestParams) params).getUserId();
         final String body = ((LiClientRequestParams.LiReportAbuseClientRequestParams) params).getBody();
-        final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(),
-                String.format("/community/2.0/%s/abuse_reports", LiSDKManager.getInstance().getTenantId()));
+        final String path = String.format(API_PATH_PREFIX, LiSDKManager.getInstance().getTenantId(), "abuse_reports");
+        final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(), path);
 
         LiMarkAbuseModel liMarkAbuseModel = new LiMarkAbuseModel();
         liMarkAbuseModel.setType(LiQueryConstant.LI_MARK_ABUSE_TYPE);
@@ -627,10 +629,10 @@ public class LiClientManager {
         params.validate(Client.LI_DEVICE_ID_FETCH_CLIENT);
 
         final String deviceId = ((LiClientRequestParams.LiDeviceIdFetchClientRequestParams) params).getDeviceId();
-        final String pushNotificationProvider = ((LiClientRequestParams.LiDeviceIdFetchClientRequestParams) params)
-                .getPushNotificationProvider();
-        final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(),
-                String.format("/community/2.0/%s/user_device_data", LiSDKManager.getInstance().getTenantId()));
+        final String pushNotificationProvider = ((LiClientRequestParams.LiDeviceIdFetchClientRequestParams) params).getPushNotificationProvider();
+
+        String path = String.format(API_PATH_PREFIX, LiSDKManager.getInstance().getTenantId(), "user_device_data");
+        final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(), path);
 
         final LiUserDeviceDataModel liUserDeviceDataModel = new LiUserDeviceDataModel();
         liUserDeviceDataModel.setType(LiQueryConstant.LI_USER_DEVICE_ID_FETCH_TYPE);
@@ -657,8 +659,9 @@ public class LiClientManager {
         params.validate(Client.LI_DEVICE_ID_UPDATE_CLIENT);
         String deviceId = ((LiClientRequestParams.LiDeviceIdUpdateClientRequestParams) params).getDeviceId();
         String id = ((LiClientRequestParams.LiDeviceIdUpdateClientRequestParams) params).getDeviceId();
-        String path = "/community/2.0/%s/user_device_data/" + id;
-        LiBasePutClient liBasePostClient = new LiBasePutClient(params.getContext(), String.format(path, LiSDKManager.getInstance().getTenantId()));
+
+        String path = String.format(API_PATH_PREFIX, LiSDKManager.getInstance().getTenantId(), "user_device_data/" + id);
+        LiBasePutClient liBasePostClient = new LiBasePutClient(params.getContext(), path);
         LiUserDeviceIdUpdateModel liUserDeviceIdUpdateModel = new LiUserDeviceIdUpdateModel();
         liUserDeviceIdUpdateModel.setType(LiQueryConstant.LI_USER_DEVICE_ID_FETCH_TYPE);
         liUserDeviceIdUpdateModel.setDeviceId(deviceId);
@@ -710,8 +713,8 @@ public class LiClientManager {
         final String login = ((LiClientRequestParams.LiCreateUserParams) params).getLogin();
         final String password = ((LiClientRequestParams.LiCreateUserParams) params).getPassword();
 
-        final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(),
-                String.format("/community/2.0/%s/users", LiSDKManager.getInstance().getTenantId()));
+        String path = String.format(API_PATH_PREFIX, LiSDKManager.getInstance().getTenantId(), "users");
+        final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(), path);
 
         final LiCreateUpdateUserModel liCreateUpdateUserModel = new LiCreateUpdateUserModel();
         liCreateUpdateUserModel.setType(LI_USER_DETAILS_CLIENT_TYPE);
@@ -747,8 +750,8 @@ public class LiClientManager {
         final String messageId = ((LiClientRequestParams.LiMarkMessageParams) params).getMessageId();
         final boolean markUnread = ((LiClientRequestParams.LiMarkMessageParams) params).isMarkUnread();
 
-        final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(),
-                String.format("/community/2.0/%s/messages_read", LiSDKManager.getInstance().getTenantId()));
+        final String path = String.format(API_PATH_PREFIX, LiSDKManager.getInstance().getTenantId(), "messages_read");
+        final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(), path);
 
         final LiMarkMessageModel liMarkMessageModel = new LiMarkMessageModel();
         liMarkMessageModel.setType(LI_MARK_MESSAGE_CLIENT_TYPE);
@@ -780,8 +783,8 @@ public class LiClientManager {
         final String messageIds = ((LiClientRequestParams.LiMarkMessagesParams) params).getMessageIds();
         final boolean markUnread = ((LiClientRequestParams.LiMarkMessagesParams) params).isMarkUnread();
 
-        final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(),
-                String.format("/community/2.0/%s/messages_read", LiSDKManager.getInstance().getTenantId()));
+        String path = String.format(API_PATH_PREFIX, LiSDKManager.getInstance().getTenantId(), "messages_read");
+        final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(), path);
 
         final LiMarkMessagesModel liMarkMessagesModel = new LiMarkMessagesModel();
         liMarkMessagesModel.setType(LI_MARK_MESSAGE_CLIENT_TYPE);
@@ -812,9 +815,8 @@ public class LiClientManager {
         final String userId = ((LiClientRequestParams.LiMarkTopicParams) params).getUserId();
         final String topicId = ((LiClientRequestParams.LiMarkTopicParams) params).getTopicId();
         final boolean markUnread = ((LiClientRequestParams.LiMarkTopicParams) params).isMarkUnread();
-
-        final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(),
-                String.format("/community/2.0/%s/messages_read", LiSDKManager.getInstance().getTenantId()));
+        final String path = String.format(API_PATH_PREFIX, LiSDKManager.getInstance().getTenantId(), "messages_read");
+        final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(), path);
 
         LiMarkTopicModel liMarkTopicModel = new LiMarkTopicModel();
         liMarkTopicModel.setType(LI_MARK_MESSAGE_CLIENT_TYPE);
@@ -870,8 +872,8 @@ public class LiClientManager {
         }
         target.setType(targetType);
         target.setId(targetID);
-        LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(),
-                String.format("/community/2.0/%s/subscriptions", LiSDKManager.getInstance().getTenantId()));
+        String path = String.format(API_PATH_PREFIX, LiSDKManager.getInstance().getTenantId(), "subscriptions");
+        LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(), path);
         LiSubscriptionPostModel liSubscriptionPostModel = new LiSubscriptionPostModel();
         liSubscriptionPostModel.setType(LI_SUBSCRIPTIONS_CLIENT_TYPE);
         liSubscriptionPostModel.setTarget(target);
@@ -957,8 +959,8 @@ public class LiClientManager {
         final String login = liUpdateUserParams.getLogin();
         final String id = liUpdateUserParams.getId();
 
-        final LiBasePutClient liBasePutClient = new LiBasePutClient(params.getContext(),
-                String.format("/community/2.0/%s/users/%s", LiSDKManager.getInstance().getTenantId(), id));
+        final String path = String.format(API_PATH_PREFIX, LiSDKManager.getInstance().getTenantId(), String.format("users/%s", id));
+        final LiBasePutClient liBasePutClient = new LiBasePutClient(params.getContext(), path);
 
         final LiCreateUpdateUserModel liCreateUpdateUserModel = new LiCreateUpdateUserModel();
         liCreateUpdateUserModel.setType(LI_USER_DETAILS_CLIENT_TYPE);
@@ -991,13 +993,10 @@ public class LiClientManager {
         final String path = ((LiClientRequestParams.LiGenericPostClientRequestParams) params).getPath();
         final JsonElement requestBody = ((LiClientRequestParams.LiGenericPostClientRequestParams) params).getRequestBody();
 
-        final Map<String, String> additionalHeaders = ((LiClientRequestParams.LiGenericPostClientRequestParams) params)
-                .getAdditionalHttpHeaders();
+        final Map<String, String> additionalHeaders = ((LiClientRequestParams.LiGenericPostClientRequestParams) params).getAdditionalHttpHeaders();
 
-        final String requestPath = "/community/2.0/%s/" + path;
-
-        final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(),
-                String.format(requestPath, LiSDKManager.getInstance().getTenantId()), additionalHeaders);
+        final String requestPath = String.format(API_PATH_PREFIX, LiSDKManager.getInstance().getTenantId(), path);
+        final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(), requestPath, additionalHeaders);
 
         final LiGenericPostModel genericPostModel = new LiGenericPostModel();
         genericPostModel.setData(requestBody);
@@ -1054,9 +1053,9 @@ public class LiClientManager {
         params.validate(Client.LI_GENERIC_PUT_CLIENT);
         String path = ((LiClientRequestParams.LiGenericPutClientRequestParams) params).getPath();
         JsonObject requestBody = ((LiClientRequestParams.LiGenericPutClientRequestParams) params).getRequestBody();
-        String requestPath = "/community/2.0/%s/" + path;
-        LiBasePutClient liBasePutClient = new LiBasePutClient(params.getContext(),
-                String.format(requestPath, LiSDKManager.getInstance().getTenantId()));
+
+        String requestPath = String.format(API_PATH_PREFIX, LiSDKManager.getInstance().getTenantId(), path);
+        LiBasePutClient liBasePutClient = new LiBasePutClient(params.getContext(), requestPath);
         LiGenericPutModel genericPutModel = new LiGenericPutModel();
         genericPutModel.setData(requestBody);
         liBasePutClient.postModel = genericPutModel;
@@ -1130,7 +1129,7 @@ public class LiClientManager {
         String extraPathAfterId = clientRequestParams.getSubResourcePath();
         CollectionsType collectionsType = clientRequestParams.getCollectionsType();
         StringBuilder path = new StringBuilder();
-        path = path.append(String.format("/community/2.0/%s/%s/%s", LiSDKManager.getInstance().getTenantId(), collectionsType.getValue(), id));
+        path = path.append(String.format(API_PATH_PREFIX, LiSDKManager.getInstance().getTenantId(), String.format("%s/%s", collectionsType.getValue(), id)));
         if (extraPathAfterId != null) {
             path = path.append(extraPathAfterId);
         }

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiSDKManager.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiSDKManager.java
@@ -231,7 +231,7 @@ public final class LiSDKManager extends LiAuthManager {
      */
     @NonNull
     public String getCoreSDKVersion() {
-        return BuildConfig.li_sdk_core_version;
+        return BuildConfig.LI_SDK_CORE_VERSION;
     }
 
     /**

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/rest/LiAuthRestClient.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/rest/LiAuthRestClient.java
@@ -100,7 +100,7 @@ public class LiAuthRestClient {
      */
     @NonNull
     @VisibleForTesting
-    LiBaseResponse getLiBaseResponseFromResponse(Response response) throws IOException, LiRestResponseException {
+    LiBaseResponse getLiBaseResponseFromResponse(Response response) throws IOException {
         return new LiBaseResponse(response);
     }
 
@@ -207,8 +207,7 @@ public class LiAuthRestClient {
         });
     }
 
-    private void checkResponse(Response response, @NonNull LiAuthAsyncRequestCallback callback,
-            String error) throws LiRestResponseException, IOException {
+    private void checkResponse(Response response, @NonNull LiAuthAsyncRequestCallback callback, String error) throws LiRestResponseException, IOException {
         if (response != null) {
             if (response.code() == LiCoreSDKConstants.HTTP_CODE_SUCCESSFUL && response.body() != null) {
                 try {

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/rest/LiBaseResponse.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/rest/LiBaseResponse.java
@@ -16,6 +16,8 @@
 
 package lithium.community.android.sdk.rest;
 
+import android.util.Log;
+
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
@@ -40,10 +42,10 @@ public class LiBaseResponse {
     private static final String TYPE = "type";
     private static final String ITEMS = "items";
     private static final String ITEM = "item";
-    private static final String STATUS_CODE = "statusCode";
+    private static final String STATUS = "status";
     private String status;
     private String message;
-    private int httpCode;
+    private int code;
     private JsonObject data;
 
     public LiBaseResponse() {
@@ -54,24 +56,24 @@ public class LiBaseResponse {
      * Wrapping OkHttp response to LiBaseResponse.
      *
      * @param response {@link Response}
-     * @throws IOException
-     * @throws LiRestResponseException
+     * @throws IOException If the reponse if not a valid JSON Object string.
      */
-    public LiBaseResponse(Response response) throws IOException, LiRestResponseException {
+    public LiBaseResponse(Response response) throws IOException {
 
-        httpCode = response.code();
+        code = response.code();
         String responseStr = response.body().string();
         try {
             data = LiClientManager.getRestClient().getGson().fromJson(responseStr, JsonObject.class);
-            if (httpCode == LiCoreSDKConstants.HTTP_CODE_SERVER_ERROR) {
-                if (data.has(STATUS_CODE)) {
-                    httpCode = data.get(STATUS_CODE).getAsInt();
-                }
+            if (data.has(STATUS)) {
+                status = data.get(STATUS).getAsString();
+            } else {
+                status = response.isSuccessful() ? "success" : "error";
             }
-            status = response.isSuccessful() ? "success" : "error";
             message = response.message();
         } catch (Exception ex) {
-            httpCode = LiCoreSDKConstants.HTTP_CODE_SERVER_ERROR;
+            Log.e(LiCoreSDKConstants.LI_ERROR_LOG, "Response deserialization failed");
+            ex.printStackTrace();
+            code = LiCoreSDKConstants.HTTP_CODE_SERVER_ERROR;
             status = "error";
             message = ex.getMessage();
         }
@@ -102,11 +104,11 @@ public class LiBaseResponse {
     }
 
     public int getHttpCode() {
-        return httpCode;
+        return code;
     }
 
     public void setHttpCode(int httpCode) {
-        this.httpCode = httpCode;
+        this.code = httpCode;
     }
 
     /**
@@ -115,14 +117,14 @@ public class LiBaseResponse {
      * @throws LiRestResponseException
      */
     public List<LiBaseModel> toEntityList(final String type, final Class<? extends LiBaseModel> baseModelClass,
-            final Gson gson) throws LiRestResponseException {
+                                          final Gson gson) throws LiRestResponseException {
         final String objectNamePlural = type + "s";
         return singleEntityOrListFromJson(data, objectNamePlural, type, baseModelClass, gson);
     }
 
     private List<LiBaseModel> singleEntityOrListFromJson(final JsonElement node, final String objectNamePlural,
-            final String objectName, final Class<? extends LiBaseModel> baseModelClass,
-            final Gson gson) throws LiRestResponseException {
+                                                         final String objectName, final Class<? extends LiBaseModel> baseModelClass,
+                                                         final Gson gson) throws LiRestResponseException {
         if (node != null && node.getAsJsonObject().has(DATA)) {
             JsonObject response = node.getAsJsonObject().get(DATA).getAsJsonObject();
             if (!response.has(TYPE)) {

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/rest/LiRestClient.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/rest/LiRestClient.java
@@ -250,7 +250,7 @@ public abstract class LiRestClient {
             }
 
             @Override
-            public void onResponse(Call call, Response response) throws IOException {
+            public void onResponse(Call call, Response response) {
 
                 try {
                     if (response != null) {
@@ -377,7 +377,7 @@ public abstract class LiRestClient {
             }
 
             @Override
-            public void onResponse(Call call, Response response) throws IOException {
+            public void onResponse(Call call, Response response) {
 
                 try {
                     if (response != null) {
@@ -431,8 +431,7 @@ public abstract class LiRestClient {
      * @return final request that will be sent across network.
      */
     protected Request buildRequest(LiBaseRestRequest baseRestRequest) {
-        Uri.Builder uriBuilder = new Uri.Builder().scheme("https");
-        uriBuilder.authority(sdkManager.getApiGatewayHost());
+        Uri.Builder uriBuilder = sdkManager.getCredentials().getCommunityUri().buildUpon();
         uriBuilder.appendEncodedPath(baseRestRequest.getPath());
         if (baseRestRequest.getQueryParams() != null) {
             for (String param : baseRestRequest.getQueryParams().keySet()) {

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/utils/LiCoreSDKConstants.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/utils/LiCoreSDKConstants.java
@@ -28,7 +28,6 @@ public class LiCoreSDKConstants {
     public static final String LI_VISIT_ORIGIN_TIME_KEY = "LI_VISIT_ORIGIN_TIME_KEY";
     public static final String LI_VISIT_LAST_ISSUE_TIME_KEY = "LI_VISIT_LAST_ISSUE_TIME_KEY";
     public static final String LI_DEVICE_ID = "Li_device_id";
-    public static final String LI_LOG_TAG = "LI_LOG_TAG";
     public static final String LI_RECEIVER_DEVICE_ID = "Li_receivedDeviceId";
     public static final String LI_SSO_TOKEN = "LI_SSO_TOKEN";
     public static final String LI_BEACON_TARGET_TYPE_BOARD = "board";
@@ -45,4 +44,8 @@ public class LiCoreSDKConstants {
     public static final int HTTP_CODE_SERVER_ERROR = 500;
     public static final int HTTP_CODE_SERVICE_UNAVAILABLE = 503;
     public static final long LI_MIN_IMAGE_SIZE_TO_COMPRESS = 1024 * 1024;
+
+    public static final String LI_LOG_TAG = "LiSdk";
+    public static final String LI_DEBUG_LOG = "LiSdkDebug";
+    public static final String LI_ERROR_LOG = "LiSdkError";
 }

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/utils/LiCoreSDKUtils.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/utils/LiCoreSDKUtils.java
@@ -478,7 +478,8 @@ public class LiCoreSDKUtils {
         checkNotNull(manager, MessageConstants.wasNull("manager"));
         checkNotNull(builder, MessageConstants.wasNull("builder"));
         builder.header(LiRequestHeaderConstants.LI_REQUEST_APPLICATION_IDENTIFIER, manager.getCredentials().getClientName());
-        builder.header(LiRequestHeaderConstants.LI_REQUEST_APPLICATION_VERSION, BuildConfig.li_sdk_core_version);
-        builder.header(LiRequestHeaderConstants.LI_REQUEST_VISITOR_ID, manager.getFromSecuredPreferences(context, LiCoreSDKConstants.LI_VISITOR_ID));
+        builder.header(LiRequestHeaderConstants.LI_REQUEST_APPLICATION_VERSION, BuildConfig.LI_SDK_CORE_VERSION);
+        String visitorId = manager.getFromSecuredPreferences(context, LiCoreSDKConstants.LI_VISITOR_ID);
+        builder.header(LiRequestHeaderConstants.LI_REQUEST_VISITOR_ID, visitorId != null ? visitorId : "null");
     }
 }

--- a/li-android-sdk-core/src/test/java/lithium/community/android/sdk/auth/LiAuthServiceTest.java
+++ b/li-android-sdk-core/src/test/java/lithium/community/android/sdk/auth/LiAuthServiceTest.java
@@ -32,6 +32,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.MethodSorters;
+import org.mockito.BDDMockito;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
@@ -57,9 +58,11 @@ import lithium.community.android.sdk.rest.LiRestv2Client;
 import lithium.community.android.sdk.utils.LiSystemClock;
 import okhttp3.Call;
 import okhttp3.Callback;
+import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
+import okhttp3.ResponseBody;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
@@ -81,7 +84,7 @@ import static org.powermock.api.mockito.PowerMockito.when;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({Activity.class, LiAuthService.class, LiAuthServiceImpl.class, LiAuthRestClient.class,
         OkHttpClient.class, Response.class, Gson.class, JsonObject.class, JsonElement.class, LiSystemClock.class,
-        LiRestv2Client.class, LiBaseGetClient.class, LiRestV2Request.class})
+        LiRestv2Client.class, LiBaseGetClient.class, LiRestV2Request.class, OkHttpClient.class})
 public class LiAuthServiceTest {
 
     public static final String RANDOM_STATE = "randomState";
@@ -113,6 +116,10 @@ public class LiAuthServiceTest {
         mContext = TestHelper.createMockContext();
         liAppCredentials = TestHelper.getTestAppCredentials();
         LiSDKManager.init(mContext, liAppCredentials);
+        LiRestv2Client liRestv2Client = PowerMockito.mock(LiRestv2Client.class);
+        when(liRestv2Client.getGson()).thenReturn(new Gson());
+        PowerMockito.mockStatic(LiRestv2Client.class);
+        BDDMockito.given(LiRestv2Client.getInstance()).willReturn(liRestv2Client);
     }
 
     @Test
@@ -290,7 +297,7 @@ public class LiAuthServiceTest {
     }
 
     @Test
-    public void performSyncRefreshTokenRequestTest() throws MalformedURLException, URISyntaxException, LiRestResponseException {
+    public void performSyncRefreshTokenRequestTest() throws LiRestResponseException {
         LiAuthServiceImpl liAuthService = new LiAuthServiceImpl(mContext);
         liAuthService = spy(liAuthService);
         LiAuthRestClient liAuthRestClient = spy(new LiAuthRestClient());
@@ -299,7 +306,6 @@ public class LiAuthServiceTest {
 
         String refreshtokenResponse = "{\n" +
                 "  \"data\": {\n" +
-                "    \"response\": {\n" +
                 "      \"status\": \"success\",\n" +
                 "      \"message\": \"OK\",\n" +
                 "      \"http_code\": 200,\n" +
@@ -310,7 +316,6 @@ public class LiAuthServiceTest {
                 "        \"refresh_token\": \"NJIjGeQP3rsdE2Wz46gFExlWdLpwv1kRompX5szrnXY=\",\n" +
                 "        \"token_type\": \"bearer\"\n" +
                 "      }\n" +
-                "    }\n" +
                 "  }\n" +
                 "}";
         Gson gson = new Gson();
@@ -333,7 +338,6 @@ public class LiAuthServiceTest {
 
         String refreshtokenResponse = "{\n" +
                 "  \"data\": {\n" +
-                "    \"response\": {\n" +
                 "      \"status\": \"success\",\n" +
                 "      \"message\": \"OK\",\n" +
                 "      \"http_code\": 200,\n" +
@@ -344,7 +348,6 @@ public class LiAuthServiceTest {
                 "        \"refresh_token\": \"NJIjGeQP3rsdE2Wz46gFExlWdLpwv1kRompX5szrnXY=\",\n" +
                 "        \"token_type\": \"bearer\"\n" +
                 "      }\n" +
-                "    }\n" +
                 "  }\n" +
                 "}";
         Gson gson = new Gson();
@@ -361,15 +364,18 @@ public class LiAuthServiceTest {
             PowerMockito.whenNew(OkHttpClient.class).withNoArguments().thenReturn(okHttpClient);
         } catch (Exception ignored) {
         }
-        Call call = mock(Call.class);
+        final Call call = mock(Call.class);
         final Response response = mock(Response.class);
+        when(response.code()).thenReturn(200);
+        ResponseBody responseBody = ResponseBody.create(MediaType.parse("application/json"), refreshtokenResponse);
+        when(response.body()).thenReturn(responseBody);
         when(okHttpClient.newCall(isA(Request.class))).thenReturn(call);
         doAnswer(
                 new Answer<Void>() {
                     @Override
                     public Void answer(final InvocationOnMock invocation) throws Throwable {
                         Callback callback = (Callback) invocation.getArguments()[0];
-                        callback.onResponse(isA(Call.class), response);
+                        callback.onResponse(call, response);
                         //callback.onFailure(isA(Call.class),new IOException("OnError"));
                         return null;
 
@@ -380,7 +386,7 @@ public class LiAuthServiceTest {
             PowerMockito.whenNew(LiBaseResponse.class).withArguments(response).thenReturn(liBaseResponse);
             liAuthService.performRefreshTokenRequest(callback);
         } catch (Exception ignored) {
-
+            ignored.printStackTrace();
         }
     }
 

--- a/li-android-sdk-core/src/test/java/lithium/community/android/sdk/rest/LiAuthRestClientTest.java
+++ b/li-android-sdk-core/src/test/java/lithium/community/android/sdk/rest/LiAuthRestClientTest.java
@@ -124,7 +124,7 @@ public class LiAuthRestClientTest {
         final Response finalResponse = response;
         try {
             doReturn(liBaseResponse).when(liAuthRestClient).getLiBaseResponseFromResponse(response);
-        } catch (IOException | LiRestResponseException ignored) {
+        } catch (IOException ignored) {
         }
         final IOException excep = mock(IOException.class);
         when(excep.getMessage()).thenReturn("Error authorizeAsync");
@@ -297,7 +297,7 @@ public class LiAuthRestClientTest {
         final Response finalResponse = response;
         try {
             doReturn(liBaseResponse).when(liAuthRestClient).getLiBaseResponseFromResponse(finalResponse);
-        } catch (IOException | LiRestResponseException ignored) {
+        } catch (IOException ignored) {
         }
         final IOException excep = mock(IOException.class);
         when(excep.getMessage()).thenReturn(EXCEPTION_CAUSE);

--- a/li-android-sdk-core/src/test/java/lithium/community/android/sdk/rest/LiCallTaskTest.java
+++ b/li-android-sdk-core/src/test/java/lithium/community/android/sdk/rest/LiCallTaskTest.java
@@ -32,7 +32,6 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.IOException;
-import java.util.Arrays;
 
 import lithium.community.android.sdk.exception.LiRestResponseException;
 import lithium.community.android.sdk.manager.LiClientManager;
@@ -43,8 +42,6 @@ import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.mock;
 
@@ -53,51 +50,64 @@ import static org.powermock.api.mockito.PowerMockito.mock;
 public class LiCallTaskTest {
 
     private Call call;
-    private LiBaseResponse liBaseResponse;
     private LiCallTask callTask;
-    private Response response;
-    private ResponseBody body;
-    private Request request;
-    private Protocol protocol;
-    private LiClientManager liClientManager;
-    private LiRestv2Client liRestClient;
-    private Gson gson;
-    private LiBaseRestRequest restRequest;
-    private LiAsyncRequestCallback responseCallback;
 
     @Before
-    public void setUp() throws LiRestResponseException, IOException {
+    public void setUp() throws IOException {
 
-        gson = PowerMockito.mock(Gson.class);
-        restRequest = PowerMockito.mock(LiBaseRestRequest.class);
-        responseCallback = PowerMockito.mock(LiAsyncRequestCallback.class);
-        liRestClient = PowerMockito.mock(LiRestv2Client.class);
-        byte[] bytes = new byte[100];
-        Arrays.fill(bytes, (byte) 0);
-        body = ResponseBody.create(MediaType.parse("application/json; charset=utf-8"), bytes);
-        request = PowerMockito.mock(Request.class);
-        protocol = PowerMockito.mock(Protocol.class);
-        response = PowerMockito.mock(Response.class);
+        LiRestv2Client liRestClient = PowerMockito.mock(LiRestv2Client.class);
+
+        String json = "{\n" +
+                "  \"status\": \"success\",\n" +
+                "  \"message\": \"\",\n" +
+                "  \"http_code\": 200,\n" +
+                "  \"data\": {\n" +
+                "    \"type\": \"messages\",\n" +
+                "    \"list_item_type\": \"message\",\n" +
+                "    \"size\": 1,\n" +
+                "    \"items\": [\n" +
+                "      {\n" +
+                "        \"type\": \"message\",\n" +
+                "        \"conversation\": {\n" +
+                "          \"type\": \"conversation\",\n" +
+                "          \"last_post_time\": \"2016-06-22T08:46:02.737-07:00\"\n" +
+                "        }\n" +
+                "      }\n" +
+                "    ]\n" +
+                "  },\n" +
+                "  \"metadata\": {}\n" +
+                "}";
+        byte[] bytes = json.getBytes();
+
+        ResponseBody body = ResponseBody.create(MediaType.parse("application/json; charset=utf-8"), bytes);
+        Request request = PowerMockito.mock(Request.class);
+
+        Protocol protocol = PowerMockito.mock(Protocol.class);
+
         Response.Builder builder = new Response.Builder();
         builder.code(200);
         builder.message("test");
         builder.body(body);
         builder.request(request);
         builder.protocol(protocol);
-        response = builder.build();
+        Response response = builder.build();
+
         PowerMockito.mockStatic(LiClientManager.class);
-        liClientManager = mock(LiClientManager.class);
+
+        LiClientManager liClientManager = mock(LiClientManager.class);
         when(liClientManager.getRestClient()).thenReturn(liRestClient);
-        when(liRestClient.getGson()).thenReturn(gson);
-        when(gson.fromJson(anyString(), (Class<Object>) any())).thenReturn(null);
+        when(liRestClient.getGson()).thenReturn(new Gson());
+
         call = PowerMockito.mock(Call.class);
         callTask = new LiCallTask(call);
+
         when(call.execute()).thenReturn(response);
+
         MockitoAnnotations.initMocks(this);
     }
 
     @Test
-    public void executeTest() throws LiRestResponseException, IOException {
+    public void executeTest() throws LiRestResponseException {
         Assert.assertEquals(200, callTask.execute().getHttpCode());
         PowerMockito.verifyStatic();
     }


### PR DESCRIPTION
* Refactor URL paths and response schema for all API calls.
* Add better error and debug logs.
* reuse `Gson` instance.
* Use `UriBuilder` instead of string concatenations.
* Improve unit test cases.
* Improve constant variable names for version.
* Improve `proguard` config.
* Refactor and deprecate the API Gateway Host in `LiAppCredentials`.
* Remove unnecessary throws clause in interface implementations.