### PR TITLE
Use the community instead of API Gateway to execute API calls

### DIFF
--- a/li-android-sdk-core/build.gradle
+++ b/li-android-sdk-core/build.gradle
@@ -27,7 +27,7 @@ properties.load(project.rootProject.file('local.properties').newDataInputStream(
 project.ext.set('groupId', 'lithium.community.android.sdk')
 project.ext.set('artifactId', 'li-android-sdk-core')
 
-project.ext.set('versionCode', 126001) // `major` + `minor` + `revision` + `build` (must have leading zeros up to 1000)
+project.ext.set('versionCode', 126002) // `major` + `minor` + `revision` + `build` (must have leading zeros up to 1000)
 project.ext.set('versionName', '1.2.6')
 
 project.ext.set('repositoryName', 'li-android-sdk')
@@ -57,7 +57,7 @@ android {
 
     buildTypes {
         buildTypes.each {
-            it.resValue "string", "LI_SDK_CORE_VERSION", "${project.ext.versionName}"
+            it.resValue "string", "li_sdk_core_version", "${project.ext.versionName}"
             it.buildConfigField "String", "LI_SDK_CORE_VERSION", "\"${project.ext.versionName}\""
         }
 

--- a/li-android-sdk-core/build.gradle
+++ b/li-android-sdk-core/build.gradle
@@ -27,8 +27,8 @@ properties.load(project.rootProject.file('local.properties').newDataInputStream(
 project.ext.set('groupId', 'lithium.community.android.sdk')
 project.ext.set('artifactId', 'li-android-sdk-core')
 
-project.ext.set('versionCode', 126005) // `major` + `minor` + `revision` + `build` (must have leading zeros up to 1000)
-project.ext.set('versionName', '1.2.6')
+project.ext.set('versionCode', 126006) // `major` + `minor` + `revision` + `build` (must have leading zeros up to 1000)
+project.ext.set('versionName', '1.2.6-SNAPSHOT')
 
 project.ext.set('repositoryName', 'li-android-sdk')
 project.ext.set('localReleaseDest', "${buildDir}/release/${project.ext.versionName}")

--- a/li-android-sdk-core/build.gradle
+++ b/li-android-sdk-core/build.gradle
@@ -27,7 +27,7 @@ properties.load(project.rootProject.file('local.properties').newDataInputStream(
 project.ext.set('groupId', 'lithium.community.android.sdk')
 project.ext.set('artifactId', 'li-android-sdk-core')
 
-project.ext.set('versionCode', 120611)
+project.ext.set('versionCode', 126001) // `major` + `minor` + `revision` + `build` (must have leading zeros up to 1000)
 project.ext.set('versionName', '1.2.6')
 
 project.ext.set('repositoryName', 'li-android-sdk')
@@ -57,11 +57,13 @@ android {
 
     buildTypes {
         buildTypes.each {
-            it.resValue "string", "li_sdk_core_version", "${project.ext.versionName}"
-            it.buildConfigField "String", "li_sdk_core_version", "\"${project.ext.versionName}\""
+            it.resValue "string", "LI_SDK_CORE_VERSION", "${project.ext.versionName}"
+            it.buildConfigField "String", "LI_SDK_CORE_VERSION", "\"${project.ext.versionName}\""
         }
 
         debug {
+            minifyEnabled false
+            debuggable true
             testCoverageEnabled true
         }
 

--- a/li-android-sdk-core/build.gradle
+++ b/li-android-sdk-core/build.gradle
@@ -27,7 +27,7 @@ properties.load(project.rootProject.file('local.properties').newDataInputStream(
 project.ext.set('groupId', 'lithium.community.android.sdk')
 project.ext.set('artifactId', 'li-android-sdk-core')
 
-project.ext.set('versionCode', 126002) // `major` + `minor` + `revision` + `build` (must have leading zeros up to 1000)
+project.ext.set('versionCode', 126003) // `major` + `minor` + `revision` + `build` (must have leading zeros up to 1000)
 project.ext.set('versionName', '1.2.6')
 
 project.ext.set('repositoryName', 'li-android-sdk')

--- a/li-android-sdk-core/build.gradle
+++ b/li-android-sdk-core/build.gradle
@@ -27,7 +27,7 @@ properties.load(project.rootProject.file('local.properties').newDataInputStream(
 project.ext.set('groupId', 'lithium.community.android.sdk')
 project.ext.set('artifactId', 'li-android-sdk-core')
 
-project.ext.set('versionCode', 126006) // `major` + `minor` + `revision` + `build` (must have leading zeros up to 1000)
+project.ext.set('versionCode', 126007) // `major` + `minor` + `revision` + `build` (must have leading zeros up to 1000)
 project.ext.set('versionName', '1.2.6-SNAPSHOT')
 
 project.ext.set('repositoryName', 'li-android-sdk')

--- a/li-android-sdk-core/build.gradle
+++ b/li-android-sdk-core/build.gradle
@@ -27,7 +27,7 @@ properties.load(project.rootProject.file('local.properties').newDataInputStream(
 project.ext.set('groupId', 'lithium.community.android.sdk')
 project.ext.set('artifactId', 'li-android-sdk-core')
 
-project.ext.set('versionCode', 126003) // `major` + `minor` + `revision` + `build` (must have leading zeros up to 1000)
+project.ext.set('versionCode', 126005) // `major` + `minor` + `revision` + `build` (must have leading zeros up to 1000)
 project.ext.set('versionName', '1.2.6')
 
 project.ext.set('repositoryName', 'li-android-sdk')

--- a/li-android-sdk-core/proguard-rules.pro
+++ b/li-android-sdk-core/proguard-rules.pro
@@ -26,6 +26,7 @@
 -keepattributes *
 -dontshrink
 -dontoptimize
+-dontobfuscate
 
 -assumenosideeffects class android.util.Log {
    public static boolean isLoggable(java.lang.String, int);

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/api/LiBaseClient.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/api/LiBaseClient.java
@@ -66,8 +66,8 @@ abstract class LiBaseClient implements LiClient {
         this.liRestv2Client = LiRestv2Client.getInstance();
     }
 
-    public LiBaseClient(Context context, String basePath, String type, String querySettingsType, Class<? extends LiBaseModel> responseClass,
-                        RequestType requestType) throws LiRestResponseException {
+    public LiBaseClient(Context context, String basePath, String type, String querySettingsType,
+                        Class<? extends LiBaseModel> responseClass, RequestType requestType) {
         this.context = context;
         this.type = type;
         this.querySettingsType = querySettingsType;
@@ -78,8 +78,7 @@ abstract class LiBaseClient implements LiClient {
     }
 
 
-    public LiBaseClient(Context context, String type, String querySettingsType, Class<? extends LiBaseModel> responseClass, RequestType requestType)
-            throws LiRestResponseException {
+    public LiBaseClient(Context context, String type, String querySettingsType, Class<? extends LiBaseModel> responseClass, RequestType requestType) {
         this.context = context;
         this.type = type;
         this.querySettingsType = querySettingsType;
@@ -89,8 +88,8 @@ abstract class LiBaseClient implements LiClient {
         this.requestType = requestType;
     }
 
-    public LiBaseClient(Context context, String type, String querySettingsType, Class<? extends LiBaseModel> responseClass, RequestType requestType,
-                        String pathParam) throws LiRestResponseException {
+    public LiBaseClient(Context context, String type, String querySettingsType, Class<? extends LiBaseModel> responseClass,
+                        RequestType requestType, String pathParam) {
         this.context = context;
         this.type = type;
         this.querySettingsType = querySettingsType;
@@ -167,11 +166,13 @@ abstract class LiBaseClient implements LiClient {
 
                 @Override
                 public void onError(Exception e) {
+                    e.printStackTrace();
                     liAsyncRequestCallback.onError(e);
                 }
             };
             liRestv2Client.processAsync(liRestV2Request, callback);
         } catch (RuntimeException e) {
+            e.printStackTrace();
             throw LiRestResponseException.runtimeError(e.getMessage());
         }
     }
@@ -210,11 +211,13 @@ abstract class LiBaseClient implements LiClient {
 
                 @Override
                 public void onError(Exception e) {
+                    e.printStackTrace();
                     liAsyncRequestCallback.onError(e);
                 }
             };
             liRestv2Client.uploadProcessAsync(liRestV2Request, callback, imagePath, imageName, requestBody);
         } catch (RuntimeException e) {
+            e.printStackTrace();
             throw LiRestResponseException.runtimeError(e.getMessage());
         }
     }

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/auth/LiAppCredentials.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/auth/LiAppCredentials.java
@@ -72,14 +72,17 @@ public final class LiAppCredentials {
     private final String ssoAuthorizeUri;
 
     /**
+     * <p>
      * Default public constructor for Lia SDK Credentials.
+     * </p>
      *
      * @param clientName   The client name.
      * @param clientKey    The client Id.
      * @param clientSecret The client secret.
      * @param tenantId     tenant ID of the community.
-     * @param communityURL The LIA community's URL. (scheme + host)
-     * @param deviceId     A unique static identifier for this device. Suggested Firebase instance id.
+     * @param communityURL The LIA community's URL.
+     * @param deviceId     A unique static identifier for this device. Use a GUID or Instance ID which is 'Single App' scoped with 'Install-reset' resettability
+     *                     and persistence. Example: <code>UUID.randomUUID().toString()</code> persisted in a Shared Preferences.
      */
     public LiAppCredentials(@NonNull String clientName, @NonNull String clientKey, @NonNull String clientSecret,
                             @NonNull String tenantId, @NonNull String communityURL, @NonNull String deviceId) {

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/auth/LiAppCredentials.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/auth/LiAppCredentials.java
@@ -18,6 +18,7 @@ package lithium.community.android.sdk.auth;
 
 import android.net.Uri;
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 import lithium.community.android.sdk.utils.LiCoreSDKUtils;
 import lithium.community.android.sdk.utils.LiUriUtils;
@@ -62,9 +63,6 @@ public final class LiAppCredentials {
     private final String deviceId;
 
     @NonNull
-    private final Uri apiGatewayHost;
-
-    @NonNull
     private final Uri authorizeUri;
 
     @NonNull
@@ -76,17 +74,15 @@ public final class LiAppCredentials {
     /**
      * Default public constructor for Lia SDK Credentials.
      *
-     * @param clientName     The client name.
-     * @param clientKey      The client Id.
-     * @param clientSecret   The client secret.
-     * @param tenantId       tenant ID of the community.
-     * @param communityURL   The LIA community's URL. (scheme + host)
-     * @param apiGatewayHost API gateway host. (host)
-     * @param deviceId       A unique static identifier for this device. Suggested Firebase instance id.
+     * @param clientName   The client name.
+     * @param clientKey    The client Id.
+     * @param clientSecret The client secret.
+     * @param tenantId     tenant ID of the community.
+     * @param communityURL The LIA community's URL. (scheme + host)
+     * @param deviceId     A unique static identifier for this device. Suggested Firebase instance id.
      */
     public LiAppCredentials(@NonNull String clientName, @NonNull String clientKey, @NonNull String clientSecret,
-                            @NonNull String tenantId, @NonNull String communityURL, @NonNull String apiGatewayHost,
-                            @NonNull String deviceId) {
+                            @NonNull String tenantId, @NonNull String communityURL, @NonNull String deviceId) {
         this.clientName = LiCoreSDKUtils.checkNotNullAndNotEmpty(clientName, MessageConstants.wasEmpty("clientName"));
         this.clientKey = LiCoreSDKUtils.checkNotNullAndNotEmpty(clientKey, MessageConstants.wasEmpty("clientKey"));
         this.clientSecret = LiCoreSDKUtils.checkNotNullAndNotEmpty(clientSecret, MessageConstants.wasEmpty("clientSecret"));
@@ -95,11 +91,27 @@ public final class LiAppCredentials {
         this.communityUri = Uri.parse(LiCoreSDKUtils.checkNotNullAndNotEmpty(communityURL, MessageConstants.wasEmpty("communityURL")));
         this.deviceId = LiCoreSDKUtils.checkNotNullAndNotEmpty(deviceId, MessageConstants.wasEmpty("deviceId"));
 
-        this.apiGatewayHost = Uri.parse(LiCoreSDKUtils.checkNotNullAndNotEmpty(apiGatewayHost, MessageConstants.wasEmpty("apiGatewayHost")));
-
         this.redirectUri = buildRedirectUri(communityUri);
         this.ssoAuthorizeUri = communityURL + SSO_AUTH_END_POINT;
         this.authorizeUri = this.communityUri.buildUpon().path(OAUTH_END_POINT).build();
+    }
+
+    /**
+     * Default public constructor for Lia SDK Credentials.
+     *
+     * @param clientName     The client name.
+     * @param clientKey      The client Id.
+     * @param clientSecret   The client secret.
+     * @param tenantId       tenant ID of the community.
+     * @param communityURL   The LIA community's URL. (scheme + host)
+     * @param apiGatewayHost API gateway host. (host)
+     * @param deviceId       A unique static identifier for this device. Suggested Firebase instance id.
+     * @deprecated Use {@link #LiAppCredentials(String, String, String, String, String, String)} instead.
+     */
+    public LiAppCredentials(@NonNull String clientName, @NonNull String clientKey, @NonNull String clientSecret,
+                            @NonNull String tenantId, @NonNull String communityURL, @Deprecated @Nullable String apiGatewayHost,
+                            @NonNull String deviceId) {
+        this(clientName, clientKey, clientSecret, tenantId, communityURL, deviceId);
     }
 
     private static String buildRedirectUri(Uri communityUri) {
@@ -136,9 +148,14 @@ public final class LiAppCredentials {
         return deviceId;
     }
 
+    /**
+     * The API Gateways host address.
+     *
+     * @return The API Gateway host Uri.
+     */
     @NonNull
     public Uri getApiGatewayHost() {
-        return apiGatewayHost;
+        return getCommunityUri();
     }
 
     @NonNull
@@ -173,7 +190,7 @@ public final class LiAppCredentials {
     @Deprecated
     @NonNull
     public String getApiProxyHost() {
-        return getApiGatewayHost().toString();
+        return getCommunityUri().toString();
     }
 
     @Override
@@ -190,8 +207,7 @@ public final class LiAppCredentials {
 
         return clientName.equals(that.clientName) && tenantId.equals(that.tenantId) && clientKey.equals(that.clientKey)
                 && clientSecret.equals(that.clientSecret) && communityUri.equals(that.communityUri) && deviceId.equals(that.deviceId)
-                && apiGatewayHost.equals(that.apiGatewayHost) && authorizeUri.equals(that.authorizeUri) && redirectUri.equals(that.redirectUri)
-                && ssoAuthorizeUri.equals(that.ssoAuthorizeUri);
+                && authorizeUri.equals(that.authorizeUri) && redirectUri.equals(that.redirectUri) && ssoAuthorizeUri.equals(that.ssoAuthorizeUri);
     }
 
     @Override
@@ -202,7 +218,6 @@ public final class LiAppCredentials {
         result = 31 * result + clientSecret.hashCode();
         result = 31 * result + communityUri.hashCode();
         result = 31 * result + deviceId.hashCode();
-        result = 31 * result + apiGatewayHost.hashCode();
         result = 31 * result + authorizeUri.hashCode();
         result = 31 * result + redirectUri.hashCode();
         result = 31 * result + ssoAuthorizeUri.hashCode();
@@ -222,7 +237,6 @@ public final class LiAppCredentials {
         private String clientSecret;
         private String tenantId;
         private String communityUri;
-        private String apiGatewayUri;
 
         /**
          * Default public constructor for the builder.
@@ -297,7 +311,6 @@ public final class LiAppCredentials {
          */
         @NonNull
         public Builder setApiGatewayUri(@NonNull String apiGatewayUri) {
-            this.apiGatewayUri = apiGatewayUri;
             return this;
         }
 
@@ -310,7 +323,6 @@ public final class LiAppCredentials {
          */
         @Deprecated
         public Builder setApiProxyHost(@NonNull String apiProxyHost) {
-            this.apiGatewayUri = apiProxyHost;
             return this;
         }
 
@@ -334,7 +346,7 @@ public final class LiAppCredentials {
          */
         @NonNull
         public LiAppCredentials build() {
-            return new LiAppCredentials(clientName, clientKey, clientSecret, tenantId, communityUri, apiGatewayUri, "deviceId");
+            return new LiAppCredentials(clientName, clientKey, clientSecret, tenantId, communityUri, "deviceId");
         }
     }
 }

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/auth/LiAppCredentials.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/auth/LiAppCredentials.java
@@ -111,6 +111,7 @@ public final class LiAppCredentials {
      * @param deviceId       A unique static identifier for this device. Suggested Firebase instance id.
      * @deprecated Use {@link #LiAppCredentials(String, String, String, String, String, String)} instead.
      */
+    @Deprecated
     public LiAppCredentials(@NonNull String clientName, @NonNull String clientKey, @NonNull String clientSecret,
                             @NonNull String tenantId, @NonNull String communityURL, @Deprecated @Nullable String apiGatewayHost,
                             @NonNull String deviceId) {
@@ -151,16 +152,6 @@ public final class LiAppCredentials {
         return deviceId;
     }
 
-    /**
-     * The API Gateways host address.
-     *
-     * @return The API Gateway host Uri.
-     */
-    @NonNull
-    public Uri getApiGatewayHost() {
-        return getCommunityUri();
-    }
-
     @NonNull
     public Uri getAuthorizeUri() {
         return authorizeUri;
@@ -187,8 +178,20 @@ public final class LiAppCredentials {
     }
 
     /**
+     * The API Gateways host address.
+     *
+     * @return The API Gateway host Uri.
+     * @deprecated This property is no longer used. Use {@link #getCommunityUri()} instead.
+     */
+    @Deprecated
+    @NonNull
+    public Uri getApiGatewayHost() {
+        return getCommunityUri();
+    }
+
+    /**
      * @return the API Gateways host address
-     * @deprecated Use {@link #getApiGatewayHost()}
+     * @deprecated This property is no longer used. Use {@link #getCommunityUri()} instead.
      */
     @Deprecated
     @NonNull
@@ -243,7 +246,10 @@ public final class LiAppCredentials {
 
         /**
          * Default public constructor for the builder.
+         *
+         * @deprecated Use the public constructor {@link #LiAppCredentials(String, String, String, String, String, String)} instead.
          */
+        @Deprecated
         public Builder() {
         }
 
@@ -252,7 +258,9 @@ public final class LiAppCredentials {
          *
          * @param clientName the client name.
          * @return this builder.
+         * @deprecated Use the public constructor {@link #LiAppCredentials(String, String, String, String, String, String)} instead.
          */
+        @Deprecated
         public Builder setClientName(@NonNull String clientName) {
             this.clientName = clientName;
             return this;
@@ -263,7 +271,9 @@ public final class LiAppCredentials {
          *
          * @param clientKey the client key.
          * @return this builder.
+         * @deprecated Use the public constructor {@link #LiAppCredentials(String, String, String, String, String, String)} instead.
          */
+        @Deprecated
         @NonNull
         public Builder setClientKey(@NonNull String clientKey) {
             this.clientKey = clientKey;
@@ -275,7 +285,9 @@ public final class LiAppCredentials {
          *
          * @param clientSecret the client secret.
          * @return this builder.
+         * @deprecated Use the public constructor {@link #LiAppCredentials(String, String, String, String, String, String)} instead.
          */
+        @Deprecated
         @NonNull
         public Builder setClientSecret(@NonNull String clientSecret) {
             this.clientSecret = clientSecret;
@@ -287,7 +299,9 @@ public final class LiAppCredentials {
          *
          * @param tenantId the tenant Id.
          * @return this builder.
+         * @deprecated Use the public constructor {@link #LiAppCredentials(String, String, String, String, String, String)} instead.
          */
+        @Deprecated
         @NonNull
         public Builder setTenantId(@NonNull String tenantId) {
             this.tenantId = tenantId;
@@ -299,7 +313,9 @@ public final class LiAppCredentials {
          *
          * @param communityUri the LIA community URL.
          * @return this builder.
+         * @deprecated Use the public constructor {@link #LiAppCredentials(String, String, String, String, String, String)} instead.
          */
+        @Deprecated
         @NonNull
         public Builder setCommunityUri(@NonNull String communityUri) {
             this.communityUri = communityUri;
@@ -311,7 +327,9 @@ public final class LiAppCredentials {
          *
          * @param apiGatewayUri the API Gateway host address.
          * @return this builder.
+         * @deprecated Use the public constructor {@link #LiAppCredentials(String, String, String, String, String, String)} instead.
          */
+        @Deprecated
         @NonNull
         public Builder setApiGatewayUri(@NonNull String apiGatewayUri) {
             return this;
@@ -322,7 +340,7 @@ public final class LiAppCredentials {
          *
          * @param apiProxyHost The API gateways host address.
          * @return this builder.
-         * @deprecated Use {@link #getApiGatewayHost()} instead.
+         * @deprecated Use the public constructor {@link #LiAppCredentials(String, String, String, String, String, String)} instead.
          */
         @Deprecated
         public Builder setApiProxyHost(@NonNull String apiProxyHost) {
@@ -334,7 +352,7 @@ public final class LiAppCredentials {
          *
          * @param clientAppName The client name to set
          * @return this builder
-         * @deprecated Use {@link #setClientName(String)}
+         * @deprecated Use the public constructor {@link #LiAppCredentials(String, String, String, String, String, String)} instead.
          */
         @Deprecated
         public Builder setClientAppName(@NonNull String clientAppName) {
@@ -346,7 +364,9 @@ public final class LiAppCredentials {
          * Build and return a new instance of {@link LiAppCredentials}.
          *
          * @return a new instance of {@link LiAppCredentials}.
+         * @deprecated Use the public constructor {@link #LiAppCredentials(String, String, String, String, String, String)} instead.
          */
+        @Deprecated
         @NonNull
         public LiAppCredentials build() {
             return new LiAppCredentials(clientName, clientKey, clientSecret, tenantId, communityUri, "deviceId");

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/auth/LiAuthConstants.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/auth/LiAuthConstants.java
@@ -26,6 +26,6 @@ public class LiAuthConstants {
     public static final String LOGIN_RESULT = "LOGIN_RESULT";
     public static final String AUTHORIZATION = "Authorization";
     public static final String BEARER = "Bearer ";
-    public static final String API_PROXY_DEFAULT_SEARCH_BASE_PATH = "community/2.0/%s/search";
-    public static final String API_PROXY_DEFAULT_GENERIC_BASE_PATH = "community/2.0/%s/%s";
+    public static final String API_PROXY_DEFAULT_SEARCH_BASE_PATH = "%s/api/2.0/search";
+    public static final String API_PROXY_DEFAULT_GENERIC_BASE_PATH = "%s/api/2.0/%s";
 }

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/auth/LiAuthServiceImpl.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/auth/LiAuthServiceImpl.java
@@ -265,8 +265,9 @@ public class LiAuthServiceImpl implements LiAuthService {
                         LiTokenResponse accessToken = gson.fromJson(data, LiTokenResponse.class);
 
                         // set expiry time
-                        data.addProperty("expiresAt", accessToken.getExpiresAt());
-                        accessToken.setExpiresAt(LiCoreSDKUtils.getTime(accessToken.getExpiresIn()));
+                        long expiresAt = LiCoreSDKUtils.addCurrentTime(accessToken.getExpiresIn());
+                        data.addProperty("expiresAt", expiresAt);
+                        accessToken.setExpiresAt(expiresAt);
 
                         // serialize the token and save it
                         accessToken.setJsonString(String.valueOf(data));
@@ -429,9 +430,10 @@ public class LiAuthServiceImpl implements LiAuthService {
                             JsonObject tokenData = responseData.get("data").getAsJsonObject();
 
                             LiTokenResponse tokenResponse = gson.fromJson(tokenData, LiTokenResponse.class);
-                            tokenResponse.setExpiresAt(LiCoreSDKUtils.getTime(tokenResponse.getExpiresIn()));
 
-                            tokenData.addProperty("expiresAt", tokenResponse.getExpiresAt());
+                            long expiresAt = LiCoreSDKUtils.addCurrentTime(tokenResponse.getExpiresIn());
+                            tokenResponse.setExpiresAt(expiresAt);
+                            tokenData.addProperty("expiresAt", expiresAt);
                             tokenResponse.setJsonString(tokenData.toString());
 
                             callback.onTokenRequestCompleted(tokenResponse, null);
@@ -500,9 +502,10 @@ public class LiAuthServiceImpl implements LiAuthService {
                 JsonObject tokenData = responseData.get("data").getAsJsonObject();
 
                 response = gson.fromJson(tokenData, LiTokenResponse.class);
-                response.setExpiresAt(LiCoreSDKUtils.getTime(response.getExpiresIn()));
 
-                tokenData.addProperty("expiresAt", response.getExpiresAt());
+                long expiresAt = LiCoreSDKUtils.addCurrentTime(response.getExpiresIn());
+                response.setExpiresAt(expiresAt);
+                tokenData.addProperty("expiresAt", expiresAt);
                 response.setJsonString(tokenData.toString());
 
                 response.setJsonString(tokenData.toString());

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/auth/LiAuthServiceImpl.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/auth/LiAuthServiceImpl.java
@@ -239,12 +239,7 @@ public class LiAuthServiceImpl implements LiAuthService {
         request.setClientSecret(credentials.getClientSecret());
         request.setGrantType("authorization_code");
         try {
-            String proxyHost;
-            if (response.getApiProxyHost() == null) {
-                proxyHost = credentials.getApiGatewayHost().toString();
-            } else {
-                proxyHost = response.getApiProxyHost();
-            }
+            String proxyHost = credentials.getApiGatewayHost().toString();
             String uri = "https://" + proxyHost + "/auth/v1/accessToken";
             request.setUri(Uri.parse(uri));
             client.accessTokenAsync(context, request, new LiAuthAsyncRequestCallback<LiBaseResponse>() {

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/auth/LiAuthServiceImpl.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/auth/LiAuthServiceImpl.java
@@ -176,7 +176,7 @@ public class LiAuthServiceImpl implements LiAuthService {
                 String state = liSsoAuthResponse.getState();
                 LiSSOAuthorizationRequest request = LiAuthRequestStore.getInstance().getLiOriginalRequest(state);
                 if (request == null) {
-                    Log.e(LiCoreSDKConstants.LI_ERROR_LOG, String.format("Response received for unknown request with state %s", state));
+                    Log.e(LiCoreSDKConstants.LI_ERROR_LOG_TAG, String.format("Response received for unknown request with state %s", state));
                     enablePostAuthorizationFlows(false, LiCoreSDKConstants.HTTP_CODE_FORBIDDEN);
                     return;
                 }
@@ -190,14 +190,14 @@ public class LiAuthServiceImpl implements LiAuthService {
                     });
                 } catch (LiRestResponseException e) {
                     enablePostAuthorizationFlows(false, LiCoreSDKConstants.HTTP_CODE_SERVER_ERROR);
-                    Log.e(LiCoreSDKConstants.LI_ERROR_LOG, "Error Fetching Auth Code: " + e);
+                    Log.e(LiCoreSDKConstants.LI_ERROR_LOG_TAG, "Error Fetching Auth Code: " + e);
                 }
             }
 
             @Override
             public void onError(Exception e) {
                 enablePostAuthorizationFlows(false, LiCoreSDKConstants.HTTP_CODE_SERVER_ERROR);
-                Log.e(LiCoreSDKConstants.LI_ERROR_LOG, "Error Fetching Auth Code: " + e);
+                Log.e(LiCoreSDKConstants.LI_ERROR_LOG_TAG, "Error Fetching Auth Code: " + e);
             }
         });
         dispose();
@@ -260,7 +260,7 @@ public class LiAuthServiceImpl implements LiAuthService {
                 @Override
                 public void onSuccess(LiBaseResponse response) {
                     if (response == null || response.getHttpCode() != LiCoreSDKConstants.HTTP_CODE_SUCCESSFUL) {
-                        Log.e(LiCoreSDKConstants.LI_ERROR_LOG, "Access Token API call unsuccessful.");
+                        Log.e(LiCoreSDKConstants.LI_ERROR_LOG_TAG, "Access Token API call unsuccessful.");
                         final int code = response != null ? response.getHttpCode() : LiAuthorizationException.GeneralErrors.SERVER_ERROR.code;
                         LiAuthorizationException exception = LiAuthorizationException.generalEx(code, "Error fetching access token");
                         callback.onLoginComplete(exception, false);
@@ -283,24 +283,24 @@ public class LiAuthServiceImpl implements LiAuthService {
                         accessToken.setJsonString(String.valueOf(data));
                         sdkManager.persistAuthState(context, accessToken);
 
-                        Log.d(LiCoreSDKConstants.LI_DEBUG_LOG, "Access Token API call successful");
+                        Log.d(LiCoreSDKConstants.LI_DEBUG_LOG_TAG, "Access Token API call successful");
                         getUserAfterTokenResponse(callback);
                     } else {
-                        Log.e(LiCoreSDKConstants.LI_ERROR_LOG, "Access Token API call invalid response.");
+                        Log.e(LiCoreSDKConstants.LI_ERROR_LOG_TAG, "Access Token API call invalid response.");
                         callback.onLoginComplete(LiAuthorizationException.generalEx(response.getHttpCode(), "Access Token API call invalid response."), false);
                     }
                 }
 
                 @Override
                 public void onError(Exception e) {
-                    Log.d(LiCoreSDKConstants.LI_ERROR_LOG, "Access Token API call failed");
+                    Log.d(LiCoreSDKConstants.LI_ERROR_LOG_TAG, "Access Token API call failed");
                     e.printStackTrace();
                     LiAuthorizationException ex = LiAuthorizationException.generalEx(LiAuthorizationException.GeneralErrors.SERVER_ERROR.code, e.getMessage());
                     callback.onLoginComplete(ex, false);
                 }
             });
         } catch (RuntimeException e) {
-            Log.d(LiCoreSDKConstants.LI_ERROR_LOG, "Access Token API request aborted.");
+            Log.d(LiCoreSDKConstants.LI_ERROR_LOG_TAG, "Access Token API request aborted.");
             e.printStackTrace();
             throw LiRestResponseException.runtimeError(e.getMessage());
         }
@@ -349,13 +349,13 @@ public class LiAuthServiceImpl implements LiAuthService {
 
                 @Override
                 public void onError(Exception exception) {
-                    Log.e(LiCoreSDKConstants.LI_ERROR_LOG, "SDK settings API call failed.");
+                    Log.e(LiCoreSDKConstants.LI_ERROR_LOG_TAG, "SDK settings API call failed.");
                     exception.printStackTrace();
                     callBack.onLoginComplete(null, true);
                 }
             });
         } catch (LiRestResponseException e) {
-            Log.d(LiCoreSDKConstants.LI_ERROR_LOG, "SDK settings API request aborted.");
+            Log.d(LiCoreSDKConstants.LI_ERROR_LOG_TAG, "SDK settings API request aborted.");
             e.printStackTrace();
             callBack.onLoginComplete(null, true);
         }
@@ -384,7 +384,7 @@ public class LiAuthServiceImpl implements LiAuthService {
 
                 @Override
                 public void onError(Exception e) {
-                    Log.e(LiCoreSDKConstants.LI_ERROR_LOG, "User Details API call failed.");
+                    Log.e(LiCoreSDKConstants.LI_ERROR_LOG_TAG, "User Details API call failed.");
                     e.printStackTrace();
                     getSDKSettings(callBack);
                     LiAuthorizationException ex = LiAuthorizationException.generalEx(LiAuthorizationException.GeneralErrors.SERVER_ERROR.code, e.getMessage());
@@ -392,7 +392,7 @@ public class LiAuthServiceImpl implements LiAuthService {
                 }
             });
         } catch (LiRestResponseException e) {
-            Log.e(LiCoreSDKConstants.LI_ERROR_LOG, "User Details API call aborted");
+            Log.e(LiCoreSDKConstants.LI_ERROR_LOG_TAG, "User Details API call aborted");
             e.printStackTrace();
             getSDKSettings(callBack);
         }
@@ -444,12 +444,12 @@ public class LiAuthServiceImpl implements LiAuthService {
                             callback.onTokenRequestCompleted(tokenResponse, null);
                         } else {
                             String error = "Refresh Token API invalid response.";
-                            Log.e(LiCoreSDKConstants.LI_ERROR_LOG, error);
+                            Log.e(LiCoreSDKConstants.LI_ERROR_LOG_TAG, error);
                             callback.onTokenRequestCompleted(null, new InvalidObjectException(error));
                         }
                     } catch (RuntimeException e) {
                         String error = "Refresh Token API invalid response.";
-                        Log.e(LiCoreSDKConstants.LI_ERROR_LOG, error);
+                        Log.e(LiCoreSDKConstants.LI_ERROR_LOG_TAG, error);
                         e.printStackTrace();
                         callback.onTokenRequestCompleted(null, e);
                     }
@@ -457,14 +457,14 @@ public class LiAuthServiceImpl implements LiAuthService {
 
                 @Override
                 public void onError(Exception exception) {
-                    Log.e(LiCoreSDKConstants.LI_ERROR_LOG, "Refresh Token API call failed.");
+                    Log.e(LiCoreSDKConstants.LI_ERROR_LOG_TAG, "Refresh Token API call failed.");
                     exception.printStackTrace();
                     callback.onTokenRequestCompleted(null, exception);
                 }
 
             });
         } catch (RuntimeException e) {
-            Log.d(LiCoreSDKConstants.LI_ERROR_LOG, "Refresh Token API request aborted.");
+            Log.d(LiCoreSDKConstants.LI_ERROR_LOG_TAG, "Refresh Token API request aborted.");
             e.printStackTrace();
             callback.onTokenRequestCompleted(null, e);
         }
@@ -512,7 +512,7 @@ public class LiAuthServiceImpl implements LiAuthService {
             }
         } catch (RuntimeException ex) {
             String error = "Refresh Token API invalid response.";
-            Log.e(LiCoreSDKConstants.LI_ERROR_LOG, error);
+            Log.e(LiCoreSDKConstants.LI_ERROR_LOG_TAG, error);
             ex.printStackTrace();
             throw LiRestResponseException.runtimeError(error);
         }

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/auth/LiAuthServiceImpl.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/auth/LiAuthServiceImpl.java
@@ -89,6 +89,17 @@ public class LiAuthServiceImpl implements LiAuthService {
         sdkManager = LiCoreSDKUtils.checkNotNull(LiSDKManager.getInstance(), "Li SDK Manager was null");
     }
 
+    private static Uri buildRefreshTokenUri(@NonNull LiAppCredentials credentials) {
+        LiCoreSDKUtils.checkNotNull(credentials, "credentials");
+        return credentials.getCommunityUri()
+                .buildUpon()
+                .appendPath(credentials.getTenantId())
+                .appendPath("api")
+                .appendPath("2.0")
+                .appendPath("auth")
+                .appendPath("refreshToken")
+                .build();
+    }
 
     @Override
     public void startLoginFlow() {
@@ -136,7 +147,6 @@ public class LiAuthServiceImpl implements LiAuthService {
         context.startActivity(intent);
         dispose();
     }
-
 
     /**
      * Performs Authorization (SSO flow).
@@ -405,12 +415,7 @@ public class LiAuthServiceImpl implements LiAuthService {
         request.setGrantType("refresh_token");
         request.setRefreshToken(this.sdkManager.getRefreshToken());
 
-        Uri uri = credentials.getCommunityUri()
-                .buildUpon()
-                .appendPath("auth")
-                .appendPath("v1")
-                .appendPath("refreshToken")
-                .build();
+        Uri uri = buildRefreshTokenUri(credentials);
 
         request.setUri(uri);
 
@@ -483,12 +488,7 @@ public class LiAuthServiceImpl implements LiAuthService {
         request.setGrantType("refresh_token");
         request.setRefreshToken(this.sdkManager.getRefreshToken());
 
-        Uri uri = credentials.getCommunityUri()
-                .buildUpon()
-                .appendPath("auth")
-                .appendPath("v1")
-                .appendPath("refreshToken")
-                .build();
+        Uri uri = buildRefreshTokenUri(credentials);
 
         request.setUri(uri);
 

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/auth/LiBaseAuthActivity.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/auth/LiBaseAuthActivity.java
@@ -87,6 +87,7 @@ public class LiBaseAuthActivity extends AppCompatActivity {
                 service.handleAuthorizationResponse(response, authClient, new LiAuthService.LoginCompleteCallBack() {
                     @Override
                     public void onLoginComplete(LiAuthorizationException authException, boolean isSuccess) {
+                        Log.d(LiCoreSDKConstants.LI_DEBUG_LOG_TAG, "Login complete. It was " + String.valueOf(isSuccess));
                         service.enablePostAuthorizationFlows(isSuccess, LiCoreSDKConstants.HTTP_CODE_SUCCESSFUL);
                         finish();
                     }

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/auth/LiTokenResponse.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/auth/LiTokenResponse.java
@@ -27,20 +27,25 @@ public class LiTokenResponse {
 
     @SerializedName("lithiumUserId")
     private String lithiumUserId;
+
     @SerializedName("access_token")
     private String accessToken;
+
     @SerializedName("refresh_token")
     private String refreshToken;
+
     @SerializedName("expires_in")
-    private Long expiresIn;
+    private long expiresIn;
+
     @SerializedName("userId")
     private String userId;
+
     @SerializedName("token_type")
     private String tokenType;
 
     private String jsonString;
 
-    private Long expiresAt;
+    private long expiresAt;
 
     public String getJsonString() {
         return jsonString;
@@ -74,19 +79,19 @@ public class LiTokenResponse {
         this.refreshToken = refreshToken;
     }
 
-    public Long getExpiresIn() {
+    public long getExpiresIn() {
         return expiresIn;
     }
 
-    public void setExpiresIn(Long expiresIn) {
+    public void setExpiresIn(long expiresIn) {
         this.expiresIn = expiresIn;
     }
 
-    public Long getExpiresAt() {
+    public long getExpiresAt() {
         return expiresAt;
     }
 
-    public void setExpiresAt(Long expiresAt) {
+    public void setExpiresAt(long expiresAt) {
         this.expiresAt = expiresAt;
     }
 

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiAuthManager.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiAuthManager.java
@@ -283,13 +283,18 @@ class LiAuthManager {
      * Gets the API gateway's host address.
      *
      * @return the API gateway's host address.
+     * @deprecated Use {@link #getCredentials()} and call {@link LiAppCredentials#getCommunityUri()} instead.
      */
+    @Deprecated
     public String getApiGatewayHost() {
-        return credentials.getApiGatewayHost().toString();
+        return credentials.getCommunityUri().toString();
     }
 
     /**
-     * @deprecated Use {@link #getApiGatewayHost()} instead.
+     * Gets the API gateway's host address.
+     *
+     * @return the API gateway's host address.
+     * @deprecated Use {@link #getCredentials()} and call {@link LiAppCredentials#getCommunityUri()} instead.
      */
     @Deprecated
     public String getProxyHost() {

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiAuthManager.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiAuthManager.java
@@ -268,7 +268,6 @@ class LiAuthManager {
         if (!TextUtils.isEmpty(json)) {
             try {
                 state = LiAuthState.deserialize(json);
-                return state;
             } catch (JSONException e) {
                 Log.e(LiCoreSDKConstants.LI_ERROR_LOG_TAG, "LiAuthManager#restoreAuthState() - deserialization of auth state failed");
                 e.printStackTrace();
@@ -276,7 +275,8 @@ class LiAuthManager {
         } else {
             Log.d(LiCoreSDKConstants.LI_DEBUG_LOG_TAG, "LiAuthManager#restoreAuthState() - No saved auth state found");
         }
-        return null;
+
+        return state;
     }
 
     /**
@@ -298,7 +298,7 @@ class LiAuthManager {
      */
     @Deprecated
     public String getProxyHost() {
-        return getApiGatewayHost();
+        return credentials.getCommunityUri().toString();
     }
 
     /**

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiAuthManager.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiAuthManager.java
@@ -107,6 +107,11 @@ class LiAuthManager {
      */
     @Nullable
     public LiUser getLoggedInUser() {
+        if (state != null) {
+            Log.d(LiCoreSDKConstants.LI_DEBUG_LOG_TAG, "LiAuthManager#getLoggedInUser() - Li Auth State is not null");
+        } else {
+            Log.e(LiCoreSDKConstants.LI_DEBUG_LOG_TAG, "LiAuthManager#getLoggedInUser() - Li Auth State is null");
+        }
         return state != null ? state.getUser() : null;
     }
 
@@ -117,8 +122,16 @@ class LiAuthManager {
      */
     public void setLoggedInUser(@NonNull Context context, @Nullable LiUser user) {
         if (state != null) {
+            Log.d(LiCoreSDKConstants.LI_DEBUG_LOG_TAG, "LiAuthManager#setLoggedInUser() - Li Auth State is not null");
+            if (user != null) {
+                Log.d(LiCoreSDKConstants.LI_DEBUG_LOG_TAG, "LiAuthManager#setLoggedInUser() - Li User is not null");
+            } else {
+                Log.e(LiCoreSDKConstants.LI_DEBUG_LOG_TAG, "LiAuthManager#setLoggedInUser() - Li User is null");
+            }
             state.setUser(user);
             putInSecuredPreferences(context, LI_AUTH_STATE, state.toJsonString());
+        } else {
+            Log.e(LiCoreSDKConstants.LI_DEBUG_LOG_TAG, "Li Auth State is null");
         }
     }
 
@@ -170,12 +183,13 @@ class LiAuthManager {
     /**
      * persists Auth State in shared preference when  Authorization Response is received
      *
-     * @param context               {@link Context}
-     * @param authorizationResponse {@link LiSSOAuthResponse}
+     * @param context  {@link Context}
+     * @param response {@link LiSSOAuthResponse}
      */
-    public void persistAuthState(Context context, @NonNull LiSSOAuthResponse authorizationResponse) {
+    public void persistAuthState(Context context, @NonNull LiSSOAuthResponse response) {
         this.state = new LiAuthState();
-        state.update(authorizationResponse);
+        Log.d(LiCoreSDKConstants.LI_DEBUG_LOG_TAG, "LiAuthManager#persistAuthState() - persisting SSO auth state");
+        state.update(response);
         putInSecuredPreferences(context, LI_AUTH_STATE, state.toJsonString());
     }
 
@@ -187,8 +201,11 @@ class LiAuthManager {
      */
     public void persistAuthState(Context context, @NonNull LiTokenResponse response) {
         if (this.state != null) {
+            Log.d(LiCoreSDKConstants.LI_DEBUG_LOG_TAG, "LiAuthManager#persistAuthState() - persisting auth state");
             this.state.update(response);
             putInSecuredPreferences(context, LI_AUTH_STATE, state.toJsonString());
+        } else {
+            Log.e(LiCoreSDKConstants.LI_ERROR_LOG_TAG, "LiAuthManager#persistAuthState() - auth state is null");
         }
     }
 
@@ -198,6 +215,8 @@ class LiAuthManager {
      * @param context {@link Context}
      */
     public void logout(@NonNull Context context) {
+        Log.d(LiCoreSDKConstants.LI_DEBUG_LOG_TAG, "LiAuthManager#logout() - logging out from SDK");
+
         LiCoreSDKUtils.checkNotNull(context, MessageConstants.wasNull("context"));
 
         preferences.clear(context);
@@ -205,11 +224,11 @@ class LiAuthManager {
         // For clearing cookies, if the android OS is Lollipop (5.0) and above use new
         // way of using CookieManager else use the deprecate methods for older versions.
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP_MR1) {
-            Log.d(LiCoreSDKConstants.LI_LOG_TAG, "Using clearCookies code for API >= " + String.valueOf(Build.VERSION_CODES.LOLLIPOP_MR1));
+            Log.d(LiCoreSDKConstants.LI_LOG_TAG, "Using clearCookies code for API >=" + String.valueOf(Build.VERSION_CODES.LOLLIPOP_MR1));
             CookieManager.getInstance().removeAllCookies(null);
             CookieManager.getInstance().flush();
         } else {
-            Log.d(LiCoreSDKConstants.LI_LOG_TAG, "Using clearCookies code for API < " + String.valueOf(Build.VERSION_CODES.LOLLIPOP_MR1));
+            Log.d(LiCoreSDKConstants.LI_LOG_TAG, "Using clearCookies code for API <" + String.valueOf(Build.VERSION_CODES.LOLLIPOP_MR1));
             CookieSyncManager manager = CookieSyncManager.createInstance(context);
 
             //noinspection deprecation tagets old API version
@@ -244,15 +263,18 @@ class LiAuthManager {
      */
     @Nullable
     public final LiAuthState restoreAuthState(Context context) {
+        Log.d(LiCoreSDKConstants.LI_DEBUG_LOG_TAG, "LiAuthManager#restoreAuthState() - restoring auth state");
         String json = getFromSecuredPreferences(context, LI_AUTH_STATE);
         if (!TextUtils.isEmpty(json)) {
             try {
                 state = LiAuthState.deserialize(json);
                 return state;
             } catch (JSONException e) {
-                Log.e(LiAuthManager.class.getSimpleName(), "Auth State deserialization failed");
+                Log.e(LiCoreSDKConstants.LI_ERROR_LOG_TAG, "LiAuthManager#restoreAuthState() - deserialization of auth state failed");
                 e.printStackTrace();
             }
+        } else {
+            Log.d(LiCoreSDKConstants.LI_DEBUG_LOG_TAG, "LiAuthManager#restoreAuthState() - No saved auth state found");
         }
         return null;
     }

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiAuthManager.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiAuthManager.java
@@ -263,7 +263,7 @@ class LiAuthManager {
      * @return the API gateway's host address.
      */
     public String getApiGatewayHost() {
-        return state != null && !TextUtils.isEmpty(state.getProxyHost()) ? state.getProxyHost() : credentials.getApiGatewayHost().toString();
+        return credentials.getApiGatewayHost().toString();
     }
 
     /**

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiAuthState.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiAuthState.java
@@ -19,6 +19,7 @@ package lithium.community.android.sdk.manager;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
+import android.util.Log;
 
 import com.google.gson.Gson;
 
@@ -32,6 +33,7 @@ import lithium.community.android.sdk.auth.LiSSOAuthResponse;
 import lithium.community.android.sdk.auth.LiTokenResponse;
 import lithium.community.android.sdk.model.response.LiUser;
 import lithium.community.android.sdk.utils.LiClock;
+import lithium.community.android.sdk.utils.LiCoreSDKConstants;
 import lithium.community.android.sdk.utils.LiCoreSDKUtils;
 import lithium.community.android.sdk.utils.LiSystemClock;
 
@@ -106,7 +108,7 @@ class LiAuthState {
         }
 
         if (json.has(KEY_LOGGED_IN_USER)) {
-            state.user = LiUser.jsonDeserialize(json.getJSONObject(KEY_LOGGED_IN_USER));
+            state.user = LiUser.deserialize(json.getJSONObject(KEY_LOGGED_IN_USER));
         }
         if (json.has(KEY_LAST_SSO_AUTHORIZATION_RESPONSE)) {
             String string = json.getString(KEY_LAST_SSO_AUTHORIZATION_RESPONSE);
@@ -299,7 +301,7 @@ class LiAuthState {
             LiCoreSDKUtils.put(json, KEY_LI_LAST_TOKEN_RESPONSE, mLastLiTokenResponse.getJsonString());
         }
         if (user != null) {
-            LiCoreSDKUtils.put(json, KEY_LOGGED_IN_USER, user.jsonSerialize());
+            LiCoreSDKUtils.put(json, KEY_LOGGED_IN_USER, user.serialize());
         }
 
         return json;
@@ -317,11 +319,22 @@ class LiAuthState {
     /**
      * Returns user details.
      */
+    @Nullable
     public LiUser getUser() {
+        if (user != null) {
+            Log.d(LiCoreSDKConstants.LI_ERROR_LOG_TAG, "LiAuthState#getUser() - Li User is not null");
+        } else {
+            Log.d(LiCoreSDKConstants.LI_DEBUG_LOG_TAG, "LiAuthState#getUser() - Li User is null");
+        }
         return user;
     }
 
-    public void setUser(LiUser user) {
+    public void setUser(@Nullable LiUser user) {
+        if (user != null) {
+            Log.d(LiCoreSDKConstants.LI_DEBUG_LOG_TAG, "LiAuthState#setUser() - User is not null");
+        } else {
+            Log.d(LiCoreSDKConstants.LI_DEBUG_LOG_TAG, "LiAuthState#setUser() - User is null");
+        }
         this.user = user;
     }
 

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiClientManager.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiClientManager.java
@@ -84,7 +84,7 @@ import static lithium.community.android.sdk.utils.LiQueryConstant.LI_USER_DETAIL
  */
 public class LiClientManager {
 
-    private static final String API_PATH_PREFIX = "/%s/api/2.0/%s";
+    private static final String API_PATH_PREFIX = "%s/api/2.0/%s";
 
     public static LiRestv2Client getRestClient() {
         return LiRestv2Client.getInstance();

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiClientManager.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiClientManager.java
@@ -84,6 +84,8 @@ import static lithium.community.android.sdk.utils.LiQueryConstant.LI_USER_DETAIL
  */
 public class LiClientManager {
 
+    private static final String API_PATH_PREFIX = "/%s/api/2.0/%s";
+
     public static LiRestv2Client getRestClient() {
         return LiRestv2Client.getInstance();
     }
@@ -359,8 +361,8 @@ public class LiClientManager {
 
         params.validate(Client.LI_KUDO_CLIENT);
         String messageId = ((LiClientRequestParams.LiKudoClientRequestParams) params).getMessageId();
-        final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(), String.format("/community/2.0/%s/messages/%s/kudos",
-                LiSDKManager.getInstance().getTenantId(), messageId));
+        String path = String.format(API_PATH_PREFIX, LiSDKManager.getInstance().getTenantId(), String.format("messages/%s/kudos", messageId));
+        final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(), path);
 
         LiPostKudoModel liPostKudoModel = new LiPostKudoModel();
         LiMessage liMessage = new LiMessage();
@@ -402,8 +404,8 @@ public class LiClientManager {
     public static LiClient getAcceptSolutionClient(LiClientRequestParams params) throws LiRestResponseException {
         params.validate(Client.LI_ACCEPT_SOLUTION_CLIENT);
         Long messageId = ((LiClientRequestParams.LiAcceptSolutionClientRequestParams) params).getMessageId();
-        LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(),
-                String.format("/community/2.0/%s/solutions_data", LiSDKManager.getInstance().getTenantId()));
+        String path = String.format(API_PATH_PREFIX, LiSDKManager.getInstance().getTenantId(), "solutions_data");
+        LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(), path);
         LiAcceptSolutionModel liAcceptSolutionModel = new LiAcceptSolutionModel();
         liAcceptSolutionModel.setType(LiQueryConstant.LI_ACCEPT_SOLUTION_TYPE);
         liAcceptSolutionModel.setMessageid(String.valueOf(messageId));
@@ -432,8 +434,8 @@ public class LiClientManager {
         final String imageId = ((LiClientRequestParams.LiCreateMessageClientRequestParams) params).getImageId();
         final String imageName = ((LiClientRequestParams.LiCreateMessageClientRequestParams) params).getImageName();
 
-        final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(),
-                String.format("/community/2.0/%s/messages", LiSDKManager.getInstance().getTenantId()));
+        String path = String.format(API_PATH_PREFIX, LiSDKManager.getInstance().getTenantId(), "messages");
+        final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(), path);
 
         LiPostMessageModel liPostMessageModel = new LiPostMessageModel();
         LiBoard liBoard = new LiBoard();
@@ -470,8 +472,8 @@ public class LiClientManager {
         final String body = ((LiClientRequestParams.LiUpdateMessageClientRequestParams) params).getBody();
         final String messageId = ((LiClientRequestParams.LiUpdateMessageClientRequestParams) params).getMessageId();
 
-        final LiBasePutClient liBasePutClient = new LiBasePutClient(params.getContext(),
-                String.format("/community/2.0/%s/messages/%s", LiSDKManager.getInstance().getTenantId(), messageId));
+        final String path = String.format(API_PATH_PREFIX, LiSDKManager.getInstance().getTenantId(), String.format("messages/%s", messageId));
+        final LiBasePutClient liBasePutClient = new LiBasePutClient(params.getContext(), path);
         LiPostMessageModel liPostMessageModel = new LiPostMessageModel();
         liPostMessageModel.setType(LI_POST_QUESTION_TYPE);
         liPostMessageModel.setBody(body);
@@ -518,8 +520,8 @@ public class LiClientManager {
         final Long messageId = ((LiClientRequestParams.LiCreateReplyClientRequestParams) params).getMessageId();
         final String imageId = ((LiClientRequestParams.LiCreateReplyClientRequestParams) params).getImageId();
         final String imageName = ((LiClientRequestParams.LiCreateReplyClientRequestParams) params).getImageName();
-        final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(),
-                String.format("/community/2.0/%s/messages", LiSDKManager.getInstance().getTenantId()));
+        String path = String.format(API_PATH_PREFIX, LiSDKManager.getInstance().getTenantId(), "messages");
+        final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(), path);
 
         final LiReplyMessageModel liReplyMessage = new LiReplyMessageModel();
         LiMessage parent = new LiMessage();
@@ -560,8 +562,8 @@ public class LiClientManager {
         final String description = ((LiClientRequestParams.LiUploadImageClientRequestParams) params).getDescription();
         final String imageName = ((LiClientRequestParams.LiUploadImageClientRequestParams) params).getImageName();
         final String path = ((LiClientRequestParams.LiUploadImageClientRequestParams) params).getPath();
-        final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(),
-                String.format("/community/2.0/%s/images", LiSDKManager.getInstance().getTenantId()), path, imageName);
+        String urlPath = String.format(API_PATH_PREFIX, LiSDKManager.getInstance().getTenantId(), "images");
+        final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(), urlPath, path, imageName);
 
         LiUploadImageModel uploadImageModel = new LiUploadImageModel();
         uploadImageModel.setType(LiQueryConstant.LI_IMAGE_TYPE);
@@ -592,8 +594,8 @@ public class LiClientManager {
         final String messageId = ((LiClientRequestParams.LiReportAbuseClientRequestParams) params).getMessageId();
         final String userId = ((LiClientRequestParams.LiReportAbuseClientRequestParams) params).getUserId();
         final String body = ((LiClientRequestParams.LiReportAbuseClientRequestParams) params).getBody();
-        final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(),
-                String.format("/community/2.0/%s/abuse_reports", LiSDKManager.getInstance().getTenantId()));
+        final String path = String.format(API_PATH_PREFIX, LiSDKManager.getInstance().getTenantId(), "abuse_reports");
+        final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(), path);
 
         LiMarkAbuseModel liMarkAbuseModel = new LiMarkAbuseModel();
         liMarkAbuseModel.setType(LiQueryConstant.LI_MARK_ABUSE_TYPE);
@@ -627,10 +629,10 @@ public class LiClientManager {
         params.validate(Client.LI_DEVICE_ID_FETCH_CLIENT);
 
         final String deviceId = ((LiClientRequestParams.LiDeviceIdFetchClientRequestParams) params).getDeviceId();
-        final String pushNotificationProvider = ((LiClientRequestParams.LiDeviceIdFetchClientRequestParams) params)
-                .getPushNotificationProvider();
-        final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(),
-                String.format("/community/2.0/%s/user_device_data", LiSDKManager.getInstance().getTenantId()));
+        final String pushNotificationProvider = ((LiClientRequestParams.LiDeviceIdFetchClientRequestParams) params).getPushNotificationProvider();
+
+        String path = String.format(API_PATH_PREFIX, LiSDKManager.getInstance().getTenantId(), "user_device_data");
+        final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(), path);
 
         final LiUserDeviceDataModel liUserDeviceDataModel = new LiUserDeviceDataModel();
         liUserDeviceDataModel.setType(LiQueryConstant.LI_USER_DEVICE_ID_FETCH_TYPE);
@@ -657,8 +659,9 @@ public class LiClientManager {
         params.validate(Client.LI_DEVICE_ID_UPDATE_CLIENT);
         String deviceId = ((LiClientRequestParams.LiDeviceIdUpdateClientRequestParams) params).getDeviceId();
         String id = ((LiClientRequestParams.LiDeviceIdUpdateClientRequestParams) params).getDeviceId();
-        String path = "/community/2.0/%s/user_device_data/" + id;
-        LiBasePutClient liBasePostClient = new LiBasePutClient(params.getContext(), String.format(path, LiSDKManager.getInstance().getTenantId()));
+
+        String path = String.format(API_PATH_PREFIX, LiSDKManager.getInstance().getTenantId(), "user_device_data/" + id);
+        LiBasePutClient liBasePostClient = new LiBasePutClient(params.getContext(), path);
         LiUserDeviceIdUpdateModel liUserDeviceIdUpdateModel = new LiUserDeviceIdUpdateModel();
         liUserDeviceIdUpdateModel.setType(LiQueryConstant.LI_USER_DEVICE_ID_FETCH_TYPE);
         liUserDeviceIdUpdateModel.setDeviceId(deviceId);
@@ -710,8 +713,8 @@ public class LiClientManager {
         final String login = ((LiClientRequestParams.LiCreateUserParams) params).getLogin();
         final String password = ((LiClientRequestParams.LiCreateUserParams) params).getPassword();
 
-        final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(),
-                String.format("/community/2.0/%s/users", LiSDKManager.getInstance().getTenantId()));
+        String path = String.format(API_PATH_PREFIX, LiSDKManager.getInstance().getTenantId(), "users");
+        final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(), path);
 
         final LiCreateUpdateUserModel liCreateUpdateUserModel = new LiCreateUpdateUserModel();
         liCreateUpdateUserModel.setType(LI_USER_DETAILS_CLIENT_TYPE);
@@ -747,8 +750,8 @@ public class LiClientManager {
         final String messageId = ((LiClientRequestParams.LiMarkMessageParams) params).getMessageId();
         final boolean markUnread = ((LiClientRequestParams.LiMarkMessageParams) params).isMarkUnread();
 
-        final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(),
-                String.format("/community/2.0/%s/messages_read", LiSDKManager.getInstance().getTenantId()));
+        final String path = String.format(API_PATH_PREFIX, LiSDKManager.getInstance().getTenantId(), "messages_read");
+        final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(), path);
 
         final LiMarkMessageModel liMarkMessageModel = new LiMarkMessageModel();
         liMarkMessageModel.setType(LI_MARK_MESSAGE_CLIENT_TYPE);
@@ -780,8 +783,8 @@ public class LiClientManager {
         final String messageIds = ((LiClientRequestParams.LiMarkMessagesParams) params).getMessageIds();
         final boolean markUnread = ((LiClientRequestParams.LiMarkMessagesParams) params).isMarkUnread();
 
-        final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(),
-                String.format("/community/2.0/%s/messages_read", LiSDKManager.getInstance().getTenantId()));
+        String path = String.format(API_PATH_PREFIX, LiSDKManager.getInstance().getTenantId(), "messages_read");
+        final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(), path);
 
         final LiMarkMessagesModel liMarkMessagesModel = new LiMarkMessagesModel();
         liMarkMessagesModel.setType(LI_MARK_MESSAGE_CLIENT_TYPE);
@@ -812,9 +815,8 @@ public class LiClientManager {
         final String userId = ((LiClientRequestParams.LiMarkTopicParams) params).getUserId();
         final String topicId = ((LiClientRequestParams.LiMarkTopicParams) params).getTopicId();
         final boolean markUnread = ((LiClientRequestParams.LiMarkTopicParams) params).isMarkUnread();
-
-        final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(),
-                String.format("/community/2.0/%s/messages_read", LiSDKManager.getInstance().getTenantId()));
+        final String path = String.format(API_PATH_PREFIX, LiSDKManager.getInstance().getTenantId(), "messages_read");
+        final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(), path);
 
         LiMarkTopicModel liMarkTopicModel = new LiMarkTopicModel();
         liMarkTopicModel.setType(LI_MARK_MESSAGE_CLIENT_TYPE);
@@ -870,8 +872,8 @@ public class LiClientManager {
         }
         target.setType(targetType);
         target.setId(targetID);
-        LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(),
-                String.format("/community/2.0/%s/subscriptions", LiSDKManager.getInstance().getTenantId()));
+        String path = String.format(API_PATH_PREFIX, LiSDKManager.getInstance().getTenantId(), "subscriptions");
+        LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(), path);
         LiSubscriptionPostModel liSubscriptionPostModel = new LiSubscriptionPostModel();
         liSubscriptionPostModel.setType(LI_SUBSCRIPTIONS_CLIENT_TYPE);
         liSubscriptionPostModel.setTarget(target);
@@ -957,8 +959,8 @@ public class LiClientManager {
         final String login = liUpdateUserParams.getLogin();
         final String id = liUpdateUserParams.getId();
 
-        final LiBasePutClient liBasePutClient = new LiBasePutClient(params.getContext(),
-                String.format("/community/2.0/%s/users/%s", LiSDKManager.getInstance().getTenantId(), id));
+        final String path = String.format(API_PATH_PREFIX, LiSDKManager.getInstance().getTenantId(), String.format("users/%s", id));
+        final LiBasePutClient liBasePutClient = new LiBasePutClient(params.getContext(), path);
 
         final LiCreateUpdateUserModel liCreateUpdateUserModel = new LiCreateUpdateUserModel();
         liCreateUpdateUserModel.setType(LI_USER_DETAILS_CLIENT_TYPE);
@@ -991,13 +993,10 @@ public class LiClientManager {
         final String path = ((LiClientRequestParams.LiGenericPostClientRequestParams) params).getPath();
         final JsonElement requestBody = ((LiClientRequestParams.LiGenericPostClientRequestParams) params).getRequestBody();
 
-        final Map<String, String> additionalHeaders = ((LiClientRequestParams.LiGenericPostClientRequestParams) params)
-                .getAdditionalHttpHeaders();
+        final Map<String, String> additionalHeaders = ((LiClientRequestParams.LiGenericPostClientRequestParams) params).getAdditionalHttpHeaders();
 
-        final String requestPath = "/community/2.0/%s/" + path;
-
-        final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(),
-                String.format(requestPath, LiSDKManager.getInstance().getTenantId()), additionalHeaders);
+        final String requestPath = String.format(API_PATH_PREFIX, LiSDKManager.getInstance().getTenantId(), path);
+        final LiBasePostClient liBasePostClient = new LiBasePostClient(params.getContext(), requestPath, additionalHeaders);
 
         final LiGenericPostModel genericPostModel = new LiGenericPostModel();
         genericPostModel.setData(requestBody);
@@ -1054,9 +1053,9 @@ public class LiClientManager {
         params.validate(Client.LI_GENERIC_PUT_CLIENT);
         String path = ((LiClientRequestParams.LiGenericPutClientRequestParams) params).getPath();
         JsonObject requestBody = ((LiClientRequestParams.LiGenericPutClientRequestParams) params).getRequestBody();
-        String requestPath = "/community/2.0/%s/" + path;
-        LiBasePutClient liBasePutClient = new LiBasePutClient(params.getContext(),
-                String.format(requestPath, LiSDKManager.getInstance().getTenantId()));
+
+        String requestPath = String.format(API_PATH_PREFIX, LiSDKManager.getInstance().getTenantId(), path);
+        LiBasePutClient liBasePutClient = new LiBasePutClient(params.getContext(), requestPath);
         LiGenericPutModel genericPutModel = new LiGenericPutModel();
         genericPutModel.setData(requestBody);
         liBasePutClient.postModel = genericPutModel;
@@ -1130,7 +1129,7 @@ public class LiClientManager {
         String extraPathAfterId = clientRequestParams.getSubResourcePath();
         CollectionsType collectionsType = clientRequestParams.getCollectionsType();
         StringBuilder path = new StringBuilder();
-        path = path.append(String.format("/community/2.0/%s/%s/%s", LiSDKManager.getInstance().getTenantId(), collectionsType.getValue(), id));
+        path = path.append(String.format(API_PATH_PREFIX, LiSDKManager.getInstance().getTenantId(), String.format("%s/%s", collectionsType.getValue(), id)));
         if (extraPathAfterId != null) {
             path = path.append(extraPathAfterId);
         }

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiSDKManager.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiSDKManager.java
@@ -231,7 +231,7 @@ public final class LiSDKManager extends LiAuthManager {
      */
     @NonNull
     public String getCoreSDKVersion() {
-        return BuildConfig.li_sdk_core_version;
+        return BuildConfig.LI_SDK_CORE_VERSION;
     }
 
     /**

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiSDKManager.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiSDKManager.java
@@ -30,7 +30,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import lithium.community.android.sdk.BuildConfig;
 import lithium.community.android.sdk.auth.LiAppCredentials;
-import lithium.community.android.sdk.auth.LiAuthConstants;
 import lithium.community.android.sdk.auth.LiAuthService;
 import lithium.community.android.sdk.auth.LiAuthServiceImpl;
 import lithium.community.android.sdk.auth.LiDeviceTokenProvider;
@@ -48,7 +47,6 @@ import lithium.community.android.sdk.utils.LiCoreSDKUtils;
 import lithium.community.android.sdk.utils.LiUUIDUtils;
 import lithium.community.android.sdk.utils.MessageConstants;
 
-import static lithium.community.android.sdk.auth.LiAuthConstants.LOG_TAG;
 import static lithium.community.android.sdk.utils.LiCoreSDKConstants.LI_DEFAULT_SDK_SETTINGS;
 import static lithium.community.android.sdk.utils.LiCoreSDKConstants.LI_ERROR_LOG_TAG;
 import static lithium.community.android.sdk.utils.LiCoreSDKConstants.LI_VISITOR_ID;
@@ -162,6 +160,7 @@ public final class LiSDKManager extends LiAuthManager {
      */
     public void syncWithCommunity(final Context context) {
         if (instance.isUserLoggedIn()) {
+            Log.d(LiCoreSDKConstants.LI_DEBUG_LOG_TAG, "SDK is retrieving settings from the community");
             try {
                 String clientId = LiUUIDUtils.toUUID(getCredentials().getClientKey().getBytes()).toString();
                 LiClientRequestParams liClientRequestParams = new LiClientRequestParams.LiSdkSettingsClientRequestParams(context, clientId);
@@ -170,37 +169,40 @@ public final class LiSDKManager extends LiAuthManager {
                     @Override
                     public void onSuccess(LiBaseRestRequest request, LiGetClientResponse response) {
                         if (response != null && response.getHttpCode() == LiCoreSDKConstants.HTTP_CODE_SUCCESSFUL) {
-                            Gson gson = new Gson();
+                            Gson gson = LiClientManager.getRestClient().getGson();
                             JsonObject responseJsonObject = response.getJsonObject();
                             if (responseJsonObject.has("data")) {
                                 JsonObject dataObj = responseJsonObject.get("data").getAsJsonObject();
                                 if (dataObj.has("items")) {
                                     JsonArray items = dataObj.get("items").getAsJsonArray();
                                     if (!items.isJsonNull() && items.size() > 0) {
-                                        LiAppSdkSettings liAppSdkSettings = gson.fromJson(items.get(0), LiAppSdkSettings.class);
-                                        if (liAppSdkSettings != null) {
-                                            putInSecuredPreferences(context, LI_DEFAULT_SDK_SETTINGS, liAppSdkSettings.getAdditionalInformation());
+                                        LiAppSdkSettings settings = gson.fromJson(items.get(0), LiAppSdkSettings.class);
+                                        if (settings != null) {
+                                            Log.d(LiCoreSDKConstants.LI_DEBUG_LOG_TAG, "SDK retrieved settings from the community successfully");
+                                            putInSecuredPreferences(context, LI_DEFAULT_SDK_SETTINGS, settings.getAdditionalInformation());
                                         }
                                     }
                                 }
                             }
                         } else {
-                            Log.e(LiCoreSDKConstants.LI_LOG_TAG, "Error getting SDK settings");
+                            Log.e(LiCoreSDKConstants.LI_ERROR_LOG_TAG, "API retrieved invalid settings from the community");
                         }
                     }
 
                     @Override
                     public void onError(Exception exception) {
-                        Log.e(LiCoreSDKConstants.LI_LOG_TAG, "Error getting SDK settings: " + exception.getMessage());
+                        Log.e(LiCoreSDKConstants.LI_ERROR_LOG_TAG, "API failed to retrieve settings from the community");
                         exception.printStackTrace();
                     }
                 });
             } catch (LiRestResponseException e) {
-                Log.e(LiAuthConstants.LOG_TAG, e.getMessage());
+                Log.e(LiCoreSDKConstants.LI_ERROR_LOG_TAG, "Sync with community request aborted");
                 e.printStackTrace();
             }
+
             //get logged in user details
             try {
+                Log.d(LiCoreSDKConstants.LI_DEBUG_LOG_TAG, "SDK is retrieving logged in user details");
                 LiClientRequestParams liClientRequestParams = new LiClientRequestParams.LiUserDetailsClientRequestParams(context, "self");
                 LiClientManager.getUserDetailsClient(liClientRequestParams).processAsync(new LiAsyncRequestCallback<LiGetClientResponse>() {
                     @Override
@@ -208,19 +210,21 @@ public final class LiSDKManager extends LiAuthManager {
                         if (liClientResponse != null && liClientResponse.getHttpCode() == LiCoreSDKConstants.HTTP_CODE_SUCCESSFUL
                                 && liClientResponse.getResponse() != null && !liClientResponse.getResponse().isEmpty()) {
                             LiUser user = (LiUser) liClientResponse.getResponse().get(0).getModel();
+                            Log.d(LiCoreSDKConstants.LI_DEBUG_LOG_TAG, "SDK is setting logged in user details");
                             instance.setLoggedInUser(context, user);
                         } else {
-                            Log.e(LOG_TAG, "No user found while fetching UserDetails");
+                            Log.e(LiCoreSDKConstants.LI_ERROR_LOG_TAG, "API returned invalid user details");
                         }
                     }
 
                     @Override
                     public void onError(Exception e) {
-                        Log.e(LOG_TAG, "Unable to fetch user details: " + e);
+                        Log.e(LiCoreSDKConstants.LI_ERROR_LOG_TAG, "API failed to return user details");
+                        e.printStackTrace();
                     }
                 });
             } catch (LiRestResponseException e) {
-                Log.e(LOG_TAG, "ERROR: " + e);
+                Log.e(LiCoreSDKConstants.LI_ERROR_LOG_TAG, "User details request aborted");
                 e.printStackTrace();
             }
         }
@@ -314,20 +318,28 @@ public final class LiSDKManager extends LiAuthManager {
     /**
      * Fetches Fresh Access Token and Persists it.
      *
-     * @param context             An Android context.
-     * @param mFreshTokenCallBack {@link LiAuthService.FreshTokenCallBack}
+     * @param context  An Android context.
+     * @param callBack {@link LiAuthService.FreshTokenCallBack}
      * @throws LiRestResponseException An exception is thrown when an invalid response is received by the SDK.
      */
-    public void fetchFreshAccessToken(final Context context, final LiAuthService.FreshTokenCallBack mFreshTokenCallBack) throws LiRestResponseException {
+    public void fetchFreshAccessToken(final Context context, final LiAuthService.FreshTokenCallBack callBack) throws LiRestResponseException {
+        Log.d(LiCoreSDKConstants.LI_DEBUG_LOG_TAG, "LiAuthManager#fetchFreshAccessToken() - refreshing access token");
         new LiAuthServiceImpl(context, this).performRefreshTokenRequest(new LiAuthService.LiTokenResponseCallback() {
             @Override
             public void onTokenRequestCompleted(@Nullable LiTokenResponse response, @Nullable Exception ex) {
                 if (ex != null) {
-                    mFreshTokenCallBack.onFreshTokenFetched(false);
+                    ex.printStackTrace();
+                    callBack.onFreshTokenFetched(false);
                     return;
                 }
-                persistAuthState(context, response);
-                mFreshTokenCallBack.onFreshTokenFetched(true);
+                if (response != null) {
+                    Log.d(LiCoreSDKConstants.LI_DEBUG_LOG_TAG, "LiSDKManager#fetchFreshAccessToken() - refresh access token successful");
+                    persistAuthState(context, response);
+                    callBack.onFreshTokenFetched(true);
+                } else {
+                    Log.e(LiCoreSDKConstants.LI_ERROR_LOG_TAG, "LiSDKManager#restoreAuthState() - API returned invalid refreshed access token");
+                    callBack.onFreshTokenFetched(false);
+                }
             }
         });
     }

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiSDKManager.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/manager/LiSDKManager.java
@@ -50,7 +50,7 @@ import lithium.community.android.sdk.utils.MessageConstants;
 
 import static lithium.community.android.sdk.auth.LiAuthConstants.LOG_TAG;
 import static lithium.community.android.sdk.utils.LiCoreSDKConstants.LI_DEFAULT_SDK_SETTINGS;
-import static lithium.community.android.sdk.utils.LiCoreSDKConstants.LI_ERROR_LOG;
+import static lithium.community.android.sdk.utils.LiCoreSDKConstants.LI_ERROR_LOG_TAG;
 import static lithium.community.android.sdk.utils.LiCoreSDKConstants.LI_VISITOR_ID;
 
 /**
@@ -143,7 +143,7 @@ public final class LiSDKManager extends LiAuthManager {
      */
     public static LiSDKManager getInstance() {
         if (instance == null) {
-            Log.e(LI_ERROR_LOG, "SDK was not initialized. Call `LiSDKManager.initialize(Context, LiAppCredentials)` before invoking getInstance().");
+            Log.e(LI_ERROR_LOG_TAG, "SDK was not initialized. Call `LiSDKManager.initialize(Context, LiAppCredentials)` before invoking getInstance().");
         }
         return instance;
     }

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/model/helpers/LiAvatar.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/model/helpers/LiAvatar.java
@@ -41,7 +41,7 @@ public class LiAvatar extends LiBaseModelImpl {
     private String internal;
     private String external;
 
-    public static LiAvatar jsonDeserialize(JSONObject json) throws JSONException {
+    public static LiAvatar deserialize(JSONObject json) throws JSONException {
         LiAvatar avatar = new LiAvatar();
         avatar.setMessage(json.getString(MESSAGE_IMAGE_URL));
         avatar.setProfile(json.getString(PROFILE_IMAGE_URL));
@@ -68,7 +68,7 @@ public class LiAvatar extends LiBaseModelImpl {
      * Produces a JSON string representation of the token response for persistent storage or
      * local transmission (e.g. between activities).
      */
-    public JSONObject jsonSerialize() {
+    public JSONObject serialize() {
         JSONObject json = new JSONObject();
         LiCoreSDKUtils.put(json, PROFILE_IMAGE_URL, String.valueOf(this.getProfile()));
         LiCoreSDKUtils.put(json, MESSAGE_IMAGE_URL, this.getMessage());

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/model/response/LiUser.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/model/response/LiUser.java
@@ -17,6 +17,7 @@
 package lithium.community.android.sdk.model.response;
 
 import android.text.TextUtils;
+import android.util.Log;
 
 import com.google.gson.annotations.SerializedName;
 
@@ -27,6 +28,7 @@ import lithium.community.android.sdk.model.LiBaseModelImpl;
 import lithium.community.android.sdk.model.helpers.LiAvatar;
 import lithium.community.android.sdk.model.helpers.LiImage;
 import lithium.community.android.sdk.model.helpers.LiRanking;
+import lithium.community.android.sdk.utils.LiCoreSDKConstants;
 import lithium.community.android.sdk.utils.LiCoreSDKUtils;
 
 /**
@@ -87,19 +89,22 @@ public class LiUser extends LiBaseModelImpl {
     @SerializedName("avatar")
     private LiAvatar avatar;
 
-    public static LiUser jsonDeserialize(JSONObject jsonObject) throws JSONException {
+    public static LiUser deserialize(JSONObject jsonObject) throws JSONException {
         LiUser user = new LiUser();
         user.setId(jsonObject.getLong(USER_ID));
         LiString emailStr = new LiString();
         emailStr.setValue(jsonObject.getString(USER_EMAIL));
         user.setEmail(emailStr);
-        LiAvatar avatar = LiAvatar.jsonDeserialize(jsonObject.getJSONObject(USER_AVATAR));
+        LiAvatar avatar = LiAvatar.deserialize(jsonObject.getJSONObject(USER_AVATAR));
         user.setAvatar(avatar);
         LiString loginStr = new LiString();
         loginStr.setValue(jsonObject.getString(USER_LOGIN));
         user.setLogin(loginStr);
         user.setHref(jsonObject.getString(USER_HREF));
         user.setProfilePageUrl(jsonObject.getString(USER_VIEW_HREF));
+
+        Log.d(LiCoreSDKConstants.LI_DEBUG_LOG_TAG, "LiUser#deserialize() - " + user.toString());
+
         return user;
     }
 
@@ -349,16 +354,21 @@ public class LiUser extends LiBaseModelImpl {
      * Produces a JSON string representation of the token response for persistent storage or
      * local transmission (e.g. between activities).
      */
-    public JSONObject jsonSerialize() {
+    public JSONObject serialize() {
         JSONObject json = new JSONObject();
         LiCoreSDKUtils.putIfNotNull(json, USER_ID, String.valueOf(this.id));
         LiCoreSDKUtils.put(json, USER_EMAIL, this.email);
-        LiCoreSDKUtils.put(json, USER_AVATAR, this.avatar.jsonSerialize());
+        LiCoreSDKUtils.put(json, USER_AVATAR, this.avatar.serialize());
         LiCoreSDKUtils.put(json, USER_LOGIN, this.login.getValue());
         LiCoreSDKUtils.put(json, USER_HREF, this.href);
         if (!TextUtils.isEmpty(profilePageUrl)) {
             LiCoreSDKUtils.put(json, USER_VIEW_HREF, this.profilePageUrl);
         }
         return json;
+    }
+
+    @Override
+    public String toString() {
+        return "LiUser{email='" + login.getValue() + "'}";
     }
 }

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/notification/LiNotificationProviderImpl.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/notification/LiNotificationProviderImpl.java
@@ -35,9 +35,10 @@ import lithium.community.android.sdk.rest.LiPostClientResponse;
 import lithium.community.android.sdk.rest.LiPutClientResponse;
 import lithium.community.android.sdk.utils.LiCoreSDKConstants;
 
+import static lithium.community.android.sdk.utils.LiCoreSDKConstants.LI_DEBUG_LOG_TAG;
 import static lithium.community.android.sdk.utils.LiCoreSDKConstants.LI_DEFAULT_SDK_SETTINGS;
 import static lithium.community.android.sdk.utils.LiCoreSDKConstants.LI_DEVICE_ID;
-import static lithium.community.android.sdk.utils.LiCoreSDKConstants.LI_LOG_TAG;
+import static lithium.community.android.sdk.utils.LiCoreSDKConstants.LI_ERROR_LOG_TAG;
 import static lithium.community.android.sdk.utils.LiCoreSDKConstants.LI_RECEIVER_DEVICE_ID;
 
 /**
@@ -95,13 +96,13 @@ public class LiNotificationProviderImpl implements LiNotificationProvider {
                             }
                         }
                     } else {
-                        Log.e(LI_LOG_TAG, "Unable to fetch device id");
+                        Log.e(LI_ERROR_LOG_TAG, "Unable to fetch device id");
                     }
                 }
 
                 @Override
                 public void onError(Exception exception) {
-                    Log.e(LI_LOG_TAG, "Unable to fetch device id");
+                    Log.e(LI_ERROR_LOG_TAG, "Device Id API request failed.");
                     exception.printStackTrace();
                 }
             });
@@ -119,15 +120,15 @@ public class LiNotificationProviderImpl implements LiNotificationProvider {
                 @Override
                 public void onSuccess(LiBaseRestRequest request, LiPutClientResponse response) {
                     if (response != null && response.getHttpCode() == LiCoreSDKConstants.HTTP_CODE_SUCCESSFUL) {
-                        Log.i(LI_LOG_TAG, "Successfully updated device Id");
+                        Log.d(LI_DEBUG_LOG_TAG, "Successfully updated device Id");
                     } else {
-                        Log.e(LI_LOG_TAG, "Unable to update device Id");
+                        Log.e(LI_ERROR_LOG_TAG, "Unable to update device Id");
                     }
                 }
 
                 @Override
                 public void onError(Exception exception) {
-                    Log.e(LI_LOG_TAG, "Unable to update device Id");
+                    Log.e(LI_ERROR_LOG_TAG, "Unable to update device Id");
                     exception.printStackTrace();
                 }
             });

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/rest/LiAuthRestClient.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/rest/LiAuthRestClient.java
@@ -100,7 +100,7 @@ public class LiAuthRestClient {
      */
     @NonNull
     @VisibleForTesting
-    LiBaseResponse getLiBaseResponseFromResponse(Response response) throws IOException, LiRestResponseException {
+    LiBaseResponse getLiBaseResponseFromResponse(Response response) throws IOException {
         return new LiBaseResponse(response);
     }
 
@@ -207,8 +207,7 @@ public class LiAuthRestClient {
         });
     }
 
-    private void checkResponse(Response response, @NonNull LiAuthAsyncRequestCallback callback,
-            String error) throws LiRestResponseException, IOException {
+    private void checkResponse(Response response, @NonNull LiAuthAsyncRequestCallback callback, String error) throws LiRestResponseException, IOException {
         if (response != null) {
             if (response.code() == LiCoreSDKConstants.HTTP_CODE_SUCCESSFUL && response.body() != null) {
                 try {

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/rest/LiBaseResponse.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/rest/LiBaseResponse.java
@@ -71,7 +71,7 @@ public class LiBaseResponse {
             }
             message = response.message();
         } catch (Exception ex) {
-            Log.e(LiCoreSDKConstants.LI_ERROR_LOG, "Response deserialization failed");
+            Log.e(LiCoreSDKConstants.LI_ERROR_LOG_TAG, "Response deserialization failed");
             ex.printStackTrace();
             code = LiCoreSDKConstants.HTTP_CODE_SERVER_ERROR;
             status = "error";

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/rest/LiBaseResponse.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/rest/LiBaseResponse.java
@@ -16,6 +16,8 @@
 
 package lithium.community.android.sdk.rest;
 
+import android.util.Log;
+
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
@@ -40,10 +42,10 @@ public class LiBaseResponse {
     private static final String TYPE = "type";
     private static final String ITEMS = "items";
     private static final String ITEM = "item";
-    private static final String STATUS_CODE = "statusCode";
+    private static final String STATUS = "status";
     private String status;
     private String message;
-    private int httpCode;
+    private int code;
     private JsonObject data;
 
     public LiBaseResponse() {
@@ -54,24 +56,24 @@ public class LiBaseResponse {
      * Wrapping OkHttp response to LiBaseResponse.
      *
      * @param response {@link Response}
-     * @throws IOException
-     * @throws LiRestResponseException
+     * @throws IOException If the reponse if not a valid JSON Object string.
      */
-    public LiBaseResponse(Response response) throws IOException, LiRestResponseException {
+    public LiBaseResponse(Response response) throws IOException {
 
-        httpCode = response.code();
+        code = response.code();
         String responseStr = response.body().string();
         try {
             data = LiClientManager.getRestClient().getGson().fromJson(responseStr, JsonObject.class);
-            if (httpCode == LiCoreSDKConstants.HTTP_CODE_SERVER_ERROR) {
-                if (data.has(STATUS_CODE)) {
-                    httpCode = data.get(STATUS_CODE).getAsInt();
-                }
+            if (data.has(STATUS)) {
+                status = data.get(STATUS).getAsString();
+            } else {
+                status = response.isSuccessful() ? "success" : "error";
             }
-            status = response.isSuccessful() ? "success" : "error";
             message = response.message();
         } catch (Exception ex) {
-            httpCode = LiCoreSDKConstants.HTTP_CODE_SERVER_ERROR;
+            Log.e(LiCoreSDKConstants.LI_ERROR_LOG, "Response deserialization failed");
+            ex.printStackTrace();
+            code = LiCoreSDKConstants.HTTP_CODE_SERVER_ERROR;
             status = "error";
             message = ex.getMessage();
         }
@@ -102,11 +104,11 @@ public class LiBaseResponse {
     }
 
     public int getHttpCode() {
-        return httpCode;
+        return code;
     }
 
     public void setHttpCode(int httpCode) {
-        this.httpCode = httpCode;
+        this.code = httpCode;
     }
 
     /**
@@ -115,14 +117,14 @@ public class LiBaseResponse {
      * @throws LiRestResponseException
      */
     public List<LiBaseModel> toEntityList(final String type, final Class<? extends LiBaseModel> baseModelClass,
-            final Gson gson) throws LiRestResponseException {
+                                          final Gson gson) throws LiRestResponseException {
         final String objectNamePlural = type + "s";
         return singleEntityOrListFromJson(data, objectNamePlural, type, baseModelClass, gson);
     }
 
     private List<LiBaseModel> singleEntityOrListFromJson(final JsonElement node, final String objectNamePlural,
-            final String objectName, final Class<? extends LiBaseModel> baseModelClass,
-            final Gson gson) throws LiRestResponseException {
+                                                         final String objectName, final Class<? extends LiBaseModel> baseModelClass,
+                                                         final Gson gson) throws LiRestResponseException {
         if (node != null && node.getAsJsonObject().has(DATA)) {
             JsonObject response = node.getAsJsonObject().get(DATA).getAsJsonObject();
             if (!response.has(TYPE)) {

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/rest/LiRequestHeaderConstants.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/rest/LiRequestHeaderConstants.java
@@ -17,9 +17,10 @@
 package lithium.community.android.sdk.rest;
 
 /**
- * Created by Lithium Technologies Inc on 8/31/17.
+ * Constants for request headers for REST API calls.
+ *
+ * @author adityasharat
  */
-
 public class LiRequestHeaderConstants {
     public static final String LI_REQUEST_CONTENT_TYPE = "Content-Type";
     public static final String LI_REQUEST_APPLICATION_IDENTIFIER = "Application-Identifier";
@@ -30,6 +31,12 @@ public class LiRequestHeaderConstants {
     public static final String LI_REQUEST_CLIENT_ID = "client-id";
 
     public static final String LI_REQUEST_AUTH_SERVICE_KEY = "Auth-Service-Authorization";
-    public static final String LI_REQUEST_AUTH_SERVICE_VALUE = "LiAndroidSdk";
+    public static final String LI_REQUEST_AUTH_SERVICE_VALUE = "default";
+
+    /**
+     * Default private constructor so that an instance of this class cannot be created.
+     */
+    private LiRequestHeaderConstants() {
+    }
 
 }

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/rest/LiRequestHeaderConstants.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/rest/LiRequestHeaderConstants.java
@@ -29,4 +29,7 @@ public class LiRequestHeaderConstants {
     public static final String LI_REQUEST_VISIT_LAST_ISSUE_TIME = "Visit-Last-Issue-Time";
     public static final String LI_REQUEST_CLIENT_ID = "client-id";
 
+    public static final String LI_REQUEST_AUTH_SERVICE_KEY = "Auth-Service-Authorization";
+    public static final String LI_REQUEST_AUTH_SERVICE_VALUE = "LiAndroidSdk";
+
 }

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/rest/LiRestClient.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/rest/LiRestClient.java
@@ -461,6 +461,7 @@ public abstract class LiRestClient {
         }
         requestBuilder.header(LiRequestHeaderConstants.LI_REQUEST_CONTENT_TYPE, "application/json");
         requestBuilder.header(LiRequestHeaderConstants.LI_REQUEST_CLIENT_ID, sdkManager.getCredentials().getClientKey());
+        requestBuilder.header(LiRequestHeaderConstants.LI_REQUEST_AUTH_SERVICE_KEY, LiRequestHeaderConstants.LI_REQUEST_AUTH_SERVICE_VALUE);
         addLSIRequestHeaders(context, requestBuilder);
 
         return requestBuilder;

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/rest/LiRestClient.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/rest/LiRestClient.java
@@ -368,6 +368,7 @@ public abstract class LiRestClient {
                 request.addHeader(entry.getKey(), entry.getValue());
             }
         }
+        request.header(LiRequestHeaderConstants.LI_REQUEST_AUTH_SERVICE_KEY, LiRequestHeaderConstants.LI_REQUEST_AUTH_SERVICE_VALUE);
         OkHttpClient clientBuilder = new OkHttpClient.Builder().connectTimeout(SERVER_TIMEOUT, TimeUnit.SECONDS).build();
         Call call = clientBuilder.newCall(request.build());
         call.enqueue(new Callback() {

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/rest/LiRestClient.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/rest/LiRestClient.java
@@ -333,10 +333,7 @@ public abstract class LiRestClient {
             file = new File(imagePath);
         }
 
-        Uri.Builder uriBuilder = new Uri.Builder().scheme("https");
-        String proxyHost = sdkManager.getApiGatewayHost();
-
-        uriBuilder.authority(proxyHost);
+        Uri.Builder uriBuilder = sdkManager.getCredentials().getCommunityUri().buildUpon();
         uriBuilder.appendEncodedPath(baseRestRequest.getPath());
         if (baseRestRequest.getQueryParams() != null) {
             for (String param : baseRestRequest.getQueryParams().keySet()) {

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/rest/LiRestClient.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/rest/LiRestClient.java
@@ -250,7 +250,7 @@ public abstract class LiRestClient {
             }
 
             @Override
-            public void onResponse(Call call, Response response) throws IOException {
+            public void onResponse(Call call, Response response) {
 
                 try {
                     if (response != null) {
@@ -377,7 +377,7 @@ public abstract class LiRestClient {
             }
 
             @Override
-            public void onResponse(Call call, Response response) throws IOException {
+            public void onResponse(Call call, Response response) {
 
                 try {
                     if (response != null) {
@@ -431,8 +431,7 @@ public abstract class LiRestClient {
      * @return final request that will be sent across network.
      */
     protected Request buildRequest(LiBaseRestRequest baseRestRequest) {
-        Uri.Builder uriBuilder = new Uri.Builder().scheme("https");
-        uriBuilder.authority(sdkManager.getApiGatewayHost());
+        Uri.Builder uriBuilder = sdkManager.getCredentials().getCommunityUri().buildUpon();
         uriBuilder.appendEncodedPath(baseRestRequest.getPath());
         if (baseRestRequest.getQueryParams() != null) {
             for (String param : baseRestRequest.getQueryParams().keySet()) {

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/utils/LiCoreSDKConstants.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/utils/LiCoreSDKConstants.java
@@ -46,6 +46,12 @@ public class LiCoreSDKConstants {
     public static final long LI_MIN_IMAGE_SIZE_TO_COMPRESS = 1024 * 1024;
 
     public static final String LI_LOG_TAG = "LiSdk";
-    public static final String LI_DEBUG_LOG = "LiSdkDebug";
-    public static final String LI_ERROR_LOG = "LiSdkError";
+    public static final String LI_DEBUG_LOG_TAG = "LiSdkDebug";
+    public static final String LI_ERROR_LOG_TAG = "LiSdkError";
+
+    /**
+     * Default private constructor so that an instance of this class cannot be created.
+     */
+    private LiCoreSDKConstants() {
+    }
 }

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/utils/LiCoreSDKConstants.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/utils/LiCoreSDKConstants.java
@@ -28,7 +28,6 @@ public class LiCoreSDKConstants {
     public static final String LI_VISIT_ORIGIN_TIME_KEY = "LI_VISIT_ORIGIN_TIME_KEY";
     public static final String LI_VISIT_LAST_ISSUE_TIME_KEY = "LI_VISIT_LAST_ISSUE_TIME_KEY";
     public static final String LI_DEVICE_ID = "Li_device_id";
-    public static final String LI_LOG_TAG = "LI_LOG_TAG";
     public static final String LI_RECEIVER_DEVICE_ID = "Li_receivedDeviceId";
     public static final String LI_SSO_TOKEN = "LI_SSO_TOKEN";
     public static final String LI_BEACON_TARGET_TYPE_BOARD = "board";
@@ -45,4 +44,8 @@ public class LiCoreSDKConstants {
     public static final int HTTP_CODE_SERVER_ERROR = 500;
     public static final int HTTP_CODE_SERVICE_UNAVAILABLE = 503;
     public static final long LI_MIN_IMAGE_SIZE_TO_COMPRESS = 1024 * 1024;
+
+    public static final String LI_LOG_TAG = "LiSdk";
+    public static final String LI_DEBUG_LOG = "LiSdkDebug";
+    public static final String LI_ERROR_LOG = "LiSdkError";
 }

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/utils/LiCoreSDKUtils.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/utils/LiCoreSDKUtils.java
@@ -478,7 +478,8 @@ public class LiCoreSDKUtils {
         checkNotNull(manager, MessageConstants.wasNull("manager"));
         checkNotNull(builder, MessageConstants.wasNull("builder"));
         builder.header(LiRequestHeaderConstants.LI_REQUEST_APPLICATION_IDENTIFIER, manager.getCredentials().getClientName());
-        builder.header(LiRequestHeaderConstants.LI_REQUEST_APPLICATION_VERSION, BuildConfig.li_sdk_core_version);
-        builder.header(LiRequestHeaderConstants.LI_REQUEST_VISITOR_ID, manager.getFromSecuredPreferences(context, LiCoreSDKConstants.LI_VISITOR_ID));
+        builder.header(LiRequestHeaderConstants.LI_REQUEST_APPLICATION_VERSION, BuildConfig.LI_SDK_CORE_VERSION);
+        String visitorId = manager.getFromSecuredPreferences(context, LiCoreSDKConstants.LI_VISITOR_ID);
+        builder.header(LiRequestHeaderConstants.LI_REQUEST_VISITOR_ID, visitorId != null ? visitorId : "null");
     }
 }

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/utils/LiCoreSDKUtils.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/utils/LiCoreSDKUtils.java
@@ -463,6 +463,12 @@ public class LiCoreSDKUtils {
     }
 
     public static void sendLoginBroadcast(Context context, boolean isLoginSuccessful, int responseCode) {
+        Log.d(LiCoreSDKConstants.LI_DEBUG_LOG_TAG, "Sending login complete broadcast. Login success is " + String.valueOf(isLoginSuccessful));
+        if (LiSDKManager.getInstance().getLoggedInUser() != null) {
+            Log.d(LiCoreSDKConstants.LI_DEBUG_LOG_TAG, "LOGIN COMPLETE BROADCAST: User is not null");
+        } else {
+            Log.e(LiCoreSDKConstants.LI_ERROR_LOG_TAG, "LOGIN COMPLETE BROADCAST: User is null");
+        }
         Intent intent = new Intent(context.getString(R.string.li_login_complete_broadcast_intent));
         intent.putExtra(LiCoreSDKConstants.LOGIN_RESULT, isLoginSuccessful);
         intent.putExtra(LiCoreSDKConstants.LOGIN_RESULT_CODE, responseCode);

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/utils/LiCoreSDKUtils.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/utils/LiCoreSDKUtils.java
@@ -458,8 +458,8 @@ public class LiCoreSDKUtils {
         return outputStream.toString();
     }
 
-    public static Long getTime(Long time) {
-        return (time != null ? (time * 1000 + LiSystemClock.INSTANCE.getCurrentTimeMillis()) : null);
+    public static long addCurrentTime(long time) {
+        return time * 1000 + LiSystemClock.INSTANCE.getCurrentTimeMillis();
     }
 
     public static void sendLoginBroadcast(Context context, boolean isLoginSuccessful, int responseCode) {

--- a/li-android-sdk-core/src/test/java/lithium/community/android/sdk/TestHelper.java
+++ b/li-android-sdk-core/src/test/java/lithium/community/android/sdk/TestHelper.java
@@ -28,6 +28,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 import lithium.community.android.sdk.auth.LiAppCredentials;
 
@@ -310,14 +311,12 @@ public class TestHelper {
             "}";
 
     public static LiAppCredentials getTestAppCredentials() {
-        return new LiAppCredentials.Builder()
-                .setClientName(TEST_CLIENT_NAME)
-                .setClientKey(TEST_CLIENT_ID)
-                .setClientSecret(TEST_CLIENT_SECRET)
-                .setCommunityUri(TEST_COMMUNITY_URL)
-                .setApiGatewayUri(TEST_API_GATEWAY_HOST)
-                .setTenantId(TEST_TENANT_ID)
-                .build();
+        return new LiAppCredentials(TEST_CLIENT_NAME,
+                TEST_CLIENT_ID,
+                TEST_CLIENT_SECRET,
+                TEST_TENANT_ID,
+                TEST_COMMUNITY_URL,
+                UUID.randomUUID().toString());
     }
 
     public static Context createMockContext() {

--- a/li-android-sdk-core/src/test/java/lithium/community/android/sdk/auth/LiAppCredentialsTest.java
+++ b/li-android-sdk-core/src/test/java/lithium/community/android/sdk/auth/LiAppCredentialsTest.java
@@ -34,7 +34,6 @@ public class LiAppCredentialsTest {
         String clientKey = "clientKey";
         String clientSecret = "clientSecret";
         String communityUri = "http://www.lithium.com/";
-        String apiGatewayHost = "http://www.lithium.com/";
         String clientName = "name";
         String tenantId = "tenant";
 
@@ -44,15 +43,14 @@ public class LiAppCredentialsTest {
                 .setClientSecret(clientSecret)
                 .setTenantId(tenantId)
                 .setCommunityUri(communityUri)
-                .setApiGatewayUri(apiGatewayHost)
                 .build();
 
         Assert.assertEquals(clientName, liAppCredentials.getClientName());
         Assert.assertEquals(clientKey, liAppCredentials.getClientKey());
         Assert.assertEquals(clientSecret, liAppCredentials.getClientSecret());
         Assert.assertEquals(Uri.parse(communityUri), liAppCredentials.getCommunityUri());
-        Assert.assertEquals(Uri.parse(apiGatewayHost), liAppCredentials.getApiGatewayHost());
-        Assert.assertEquals(apiGatewayHost, liAppCredentials.getApiProxyHost());
+        Assert.assertEquals(Uri.parse(communityUri), liAppCredentials.getCommunityUri());
+        Assert.assertEquals(communityUri, liAppCredentials.getCommunityUri().toString());
         Assert.assertEquals(tenantId, liAppCredentials.getTenantId());
 
         String ssoAuthorizeUri = "http://www.lithium.com/api/2.0/auth/authorize";

--- a/li-android-sdk-core/src/test/java/lithium/community/android/sdk/auth/LiAuthServiceTest.java
+++ b/li-android-sdk-core/src/test/java/lithium/community/android/sdk/auth/LiAuthServiceTest.java
@@ -55,6 +55,7 @@ import lithium.community.android.sdk.rest.LiAuthRestClient;
 import lithium.community.android.sdk.rest.LiBaseResponse;
 import lithium.community.android.sdk.rest.LiRestV2Request;
 import lithium.community.android.sdk.rest.LiRestv2Client;
+import lithium.community.android.sdk.utils.LiCoreSDKUtils;
 import lithium.community.android.sdk.utils.LiSystemClock;
 import okhttp3.Call;
 import okhttp3.Callback;
@@ -323,9 +324,11 @@ public class LiAuthServiceTest {
         doReturn(liBaseResponse).when(liAuthRestClient).refreshTokenSync(isA(Context.class),
                 isA(LiRefreshTokenRequest.class));
 
+        long atLeast = LiCoreSDKUtils.addCurrentTime(86400L);
         LiTokenResponse tokenResponse = liAuthService.performSyncRefreshTokenRequest();
         assert (tokenResponse.getAccessToken().equals(ACCESS_TOKEN));
-
+        Assert.assertEquals(tokenResponse.getExpiresIn(), 86400L);
+        Assert.assertTrue("expiry in", tokenResponse.getExpiresAt() >= atLeast);
     }
 
     @Test

--- a/li-android-sdk-core/src/test/java/lithium/community/android/sdk/auth/LiAuthServiceTest.java
+++ b/li-android-sdk-core/src/test/java/lithium/community/android/sdk/auth/LiAuthServiceTest.java
@@ -244,9 +244,12 @@ public class LiAuthServiceTest {
         PowerMockito.doReturn(liSSOAuthResponse).when(liAuthService, "getLiSSOAuthResponse", liBaseResponse);
         OkHttpClient okHttpClient = mock(OkHttpClient.class);
         PowerMockito.whenNew(OkHttpClient.class).withNoArguments().thenReturn(okHttpClient);
-        Call call = mock(Call.class);
+        final Call call = mock(Call.class);
 
         final Response response = mock(Response.class);
+        when(response.code()).thenReturn(200);
+        ResponseBody body = mock(ResponseBody.class);
+        when(response.body()).thenReturn(body);
         when(okHttpClient.newCall(isA(Request.class))).thenReturn(call);
 
         PowerMockito.whenNew(LiBaseResponse.class).withArguments(response).thenReturn(liBaseResponse);
@@ -255,7 +258,7 @@ public class LiAuthServiceTest {
             @Override
             public Void answer(final InvocationOnMock invocation) throws Throwable {
                 Callback callback = (Callback) invocation.getArguments()[0];
-                callback.onResponse(isA(Call.class), response);
+                callback.onResponse(call, response);
                 return null;
             }
         }).when(call).enqueue(any(Callback.class));
@@ -284,9 +287,8 @@ public class LiAuthServiceTest {
 
         PowerMockito.doAnswer(new Answer<Void>() {
             @Override
-            public Void answer(final InvocationOnMock invocation) throws Throwable {
-                LiAuthService.LoginCompleteCallBack callback
-                        = (LiAuthService.LoginCompleteCallBack) invocation.getArguments()[0];
+            public Void answer(final InvocationOnMock invocation) {
+                LiAuthService.LoginCompleteCallBack callback = (LiAuthService.LoginCompleteCallBack) invocation.getArguments()[0];
                 callback.onLoginComplete(null, true);
                 return null;
             }

--- a/li-android-sdk-core/src/test/java/lithium/community/android/sdk/auth/LiAuthServiceTest.java
+++ b/li-android-sdk-core/src/test/java/lithium/community/android/sdk/auth/LiAuthServiceTest.java
@@ -32,6 +32,7 @@ import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.MethodSorters;
+import org.mockito.BDDMockito;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
@@ -57,9 +58,11 @@ import lithium.community.android.sdk.rest.LiRestv2Client;
 import lithium.community.android.sdk.utils.LiSystemClock;
 import okhttp3.Call;
 import okhttp3.Callback;
+import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
+import okhttp3.ResponseBody;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
@@ -81,7 +84,7 @@ import static org.powermock.api.mockito.PowerMockito.when;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({Activity.class, LiAuthService.class, LiAuthServiceImpl.class, LiAuthRestClient.class,
         OkHttpClient.class, Response.class, Gson.class, JsonObject.class, JsonElement.class, LiSystemClock.class,
-        LiRestv2Client.class, LiBaseGetClient.class, LiRestV2Request.class})
+        LiRestv2Client.class, LiBaseGetClient.class, LiRestV2Request.class, OkHttpClient.class})
 public class LiAuthServiceTest {
 
     public static final String RANDOM_STATE = "randomState";
@@ -113,6 +116,10 @@ public class LiAuthServiceTest {
         mContext = TestHelper.createMockContext();
         liAppCredentials = TestHelper.getTestAppCredentials();
         LiSDKManager.init(mContext, liAppCredentials);
+        LiRestv2Client liRestv2Client = PowerMockito.mock(LiRestv2Client.class);
+        when(liRestv2Client.getGson()).thenReturn(new Gson());
+        PowerMockito.mockStatic(LiRestv2Client.class);
+        BDDMockito.given(LiRestv2Client.getInstance()).willReturn(liRestv2Client);
     }
 
     @Test
@@ -290,7 +297,7 @@ public class LiAuthServiceTest {
     }
 
     @Test
-    public void performSyncRefreshTokenRequestTest() throws MalformedURLException, URISyntaxException, LiRestResponseException {
+    public void performSyncRefreshTokenRequestTest() throws LiRestResponseException {
         LiAuthServiceImpl liAuthService = new LiAuthServiceImpl(mContext);
         liAuthService = spy(liAuthService);
         LiAuthRestClient liAuthRestClient = spy(new LiAuthRestClient());
@@ -299,7 +306,6 @@ public class LiAuthServiceTest {
 
         String refreshtokenResponse = "{\n" +
                 "  \"data\": {\n" +
-                "    \"response\": {\n" +
                 "      \"status\": \"success\",\n" +
                 "      \"message\": \"OK\",\n" +
                 "      \"http_code\": 200,\n" +
@@ -310,7 +316,6 @@ public class LiAuthServiceTest {
                 "        \"refresh_token\": \"NJIjGeQP3rsdE2Wz46gFExlWdLpwv1kRompX5szrnXY=\",\n" +
                 "        \"token_type\": \"bearer\"\n" +
                 "      }\n" +
-                "    }\n" +
                 "  }\n" +
                 "}";
         Gson gson = new Gson();
@@ -333,7 +338,6 @@ public class LiAuthServiceTest {
 
         String refreshtokenResponse = "{\n" +
                 "  \"data\": {\n" +
-                "    \"response\": {\n" +
                 "      \"status\": \"success\",\n" +
                 "      \"message\": \"OK\",\n" +
                 "      \"http_code\": 200,\n" +
@@ -344,7 +348,6 @@ public class LiAuthServiceTest {
                 "        \"refresh_token\": \"NJIjGeQP3rsdE2Wz46gFExlWdLpwv1kRompX5szrnXY=\",\n" +
                 "        \"token_type\": \"bearer\"\n" +
                 "      }\n" +
-                "    }\n" +
                 "  }\n" +
                 "}";
         Gson gson = new Gson();
@@ -361,15 +364,18 @@ public class LiAuthServiceTest {
             PowerMockito.whenNew(OkHttpClient.class).withNoArguments().thenReturn(okHttpClient);
         } catch (Exception ignored) {
         }
-        Call call = mock(Call.class);
+        final Call call = mock(Call.class);
         final Response response = mock(Response.class);
+        when(response.code()).thenReturn(200);
+        ResponseBody responseBody = ResponseBody.create(MediaType.parse("application/json"), refreshtokenResponse);
+        when(response.body()).thenReturn(responseBody);
         when(okHttpClient.newCall(isA(Request.class))).thenReturn(call);
         doAnswer(
                 new Answer<Void>() {
                     @Override
                     public Void answer(final InvocationOnMock invocation) throws Throwable {
                         Callback callback = (Callback) invocation.getArguments()[0];
-                        callback.onResponse(isA(Call.class), response);
+                        callback.onResponse(call, response);
                         //callback.onFailure(isA(Call.class),new IOException("OnError"));
                         return null;
 
@@ -380,7 +386,7 @@ public class LiAuthServiceTest {
             PowerMockito.whenNew(LiBaseResponse.class).withArguments(response).thenReturn(liBaseResponse);
             liAuthService.performRefreshTokenRequest(callback);
         } catch (Exception ignored) {
-
+            ignored.printStackTrace();
         }
     }
 

--- a/li-android-sdk-core/src/test/java/lithium/community/android/sdk/auth/LiTokenResponseTest.java
+++ b/li-android-sdk-core/src/test/java/lithium/community/android/sdk/auth/LiTokenResponseTest.java
@@ -72,9 +72,9 @@ public class LiTokenResponseTest {
     @Test
     public void getExpiresAtTest() {
         liTokenResponse = new LiTokenResponse();
-        liTokenResponse.setExpiresAt(LiCoreSDKUtils.getTime(2L));
+        liTokenResponse.setExpiresAt(LiCoreSDKUtils.addCurrentTime(2L));
         assertNotEquals(null, liTokenResponse.getExpiresAt());
-        assertEquals(Long.valueOf(2001), liTokenResponse.getExpiresAt());
+        assertEquals(2001, liTokenResponse.getExpiresAt());
     }
 
     @Test
@@ -82,7 +82,7 @@ public class LiTokenResponseTest {
         liTokenResponse = new LiTokenResponse();
         liTokenResponse.setExpiresAt(2L);
         assertNotEquals(null, liTokenResponse.getExpiresAt());
-        assertEquals(Long.valueOf(2), liTokenResponse.getExpiresAt());
+        assertEquals(2, liTokenResponse.getExpiresAt());
     }
 
     @Test
@@ -90,7 +90,7 @@ public class LiTokenResponseTest {
         liTokenResponse = new LiTokenResponse();
         liTokenResponse.setExpiresIn(2L);
         assertNotEquals(null, liTokenResponse.getExpiresIn());
-        assertEquals(Long.valueOf(2), liTokenResponse.getExpiresIn());
+        assertEquals(2, liTokenResponse.getExpiresIn());
     }
 
     @Test

--- a/li-android-sdk-core/src/test/java/lithium/community/android/sdk/manager/LiAuthManagerTest.java
+++ b/li-android-sdk-core/src/test/java/lithium/community/android/sdk/manager/LiAuthManagerTest.java
@@ -26,10 +26,8 @@ import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import java.net.MalformedURLException;
-import java.net.URISyntaxException;
-
 import lithium.community.android.sdk.TestHelper;
+import lithium.community.android.sdk.exception.LiInitializationException;
 import lithium.community.android.sdk.model.LiBaseModelImpl;
 import lithium.community.android.sdk.model.helpers.LiAvatar;
 import lithium.community.android.sdk.model.helpers.LiImage;
@@ -67,10 +65,10 @@ public class LiAuthManagerTest {
 
 
     @Test
-    public void testSetLoggedInUser() throws MalformedURLException, URISyntaxException {
+    public void testSetLoggedInUser() throws LiInitializationException {
         Context context = TestHelper.createMockContext();
 
-        LiSDKManager.init(context, TestHelper.getTestAppCredentials());
+        LiSDKManager.initialize(context, TestHelper.getTestAppCredentials());
         LiSecuredPrefManager.getInstance().putString(context, LiCoreSDKConstants.LI_AUTH_STATE, AUTH_STATE_JSON);
         LiSDKManager.getInstance().restoreAuthState(context);
 

--- a/li-android-sdk-core/src/test/java/lithium/community/android/sdk/manager/LiAuthStateTest.java
+++ b/li-android-sdk-core/src/test/java/lithium/community/android/sdk/manager/LiAuthStateTest.java
@@ -107,7 +107,7 @@ public class LiAuthStateTest {
         liTokenResponse.setRefreshToken(NEW_REFRESH_TOKEN);
         liTokenResponse.setLithiumUserId(LITHIUM_USER_ID);
         liTokenResponse.setExpiresIn(EXPIRES_IN);
-        liTokenResponse.setExpiresAt(LiCoreSDKUtils.getTime(EXPIRES_IN));
+        liTokenResponse.setExpiresAt(LiCoreSDKUtils.addCurrentTime(EXPIRES_IN));
 
         String json = gson.toJson(liTokenResponse);
         liTokenResponse.setJsonString(json);

--- a/li-android-sdk-core/src/test/java/lithium/community/android/sdk/manager/LiSecuredPrefManagerTest.java
+++ b/li-android-sdk-core/src/test/java/lithium/community/android/sdk/manager/LiSecuredPrefManagerTest.java
@@ -27,6 +27,7 @@ import org.junit.rules.ExpectedException;
 import org.powermock.core.classloader.annotations.PowerMockIgnore;
 
 import java.lang.reflect.Field;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import lithium.community.android.sdk.TestHelper;
@@ -55,7 +56,7 @@ public class LiSecuredPrefManagerTest {
 
     @Test
     public void initialize() throws Exception {
-        LiSecuredPrefManager.initialize("ThisIsASecretKey");
+        LiSecuredPrefManager.initialize(UUID.randomUUID().toString());
         Assert.assertNotNull(LiSecuredPrefManager.getInstance());
     }
 
@@ -67,14 +68,14 @@ public class LiSecuredPrefManagerTest {
     }
 
     @Test
-    public void init() throws Exception {
+    public void init() {
         MockContext context = new MockContext();
         LiSecuredPrefManager instance = LiSecuredPrefManager.init(context);
         Assert.assertNotNull(instance);
     }
 
     @Test
-    public void init_null() throws Exception {
+    public void init_null() {
         thrown.expect(IllegalArgumentException.class);
         //noinspection ConstantConditions for test
         LiSecuredPrefManager instance = LiSecuredPrefManager.init(null);
@@ -83,7 +84,7 @@ public class LiSecuredPrefManagerTest {
 
     @Test
     public void getString() throws Exception {
-        LiSecuredPrefManager.initialize("ThisIsASecretKey");
+        LiSecuredPrefManager.initialize(UUID.randomUUID().toString());
         LiSecuredPrefManager instance = LiSecuredPrefManager.getInstance();
         assert instance != null;
         String string = instance.getString(context, "test");
@@ -103,7 +104,7 @@ public class LiSecuredPrefManagerTest {
     @Test
     public void getString_null_key() throws Exception {
         thrown.expect(IllegalArgumentException.class);
-        LiSecuredPrefManager.initialize("ThisIsASecretKey");
+        LiSecuredPrefManager.initialize(UUID.randomUUID().toString());
         LiSecuredPrefManager instance = LiSecuredPrefManager.getInstance();
         assert instance != null;
         //noinspection ConstantConditions for test
@@ -113,7 +114,7 @@ public class LiSecuredPrefManagerTest {
     @Test
     public void getString_null_context_null_key() throws Exception {
         thrown.expect(IllegalArgumentException.class);
-        LiSecuredPrefManager.initialize("ThisIsASecretKey");
+        LiSecuredPrefManager.initialize(UUID.randomUUID().toString());
         LiSecuredPrefManager instance = LiSecuredPrefManager.getInstance();
         assert instance != null;
         //noinspection ConstantConditions for test
@@ -122,7 +123,7 @@ public class LiSecuredPrefManagerTest {
 
     @Test
     public void putString_getString() throws Exception {
-        LiSecuredPrefManager.initialize("ThisIsASecretKey");
+        LiSecuredPrefManager.initialize(UUID.randomUUID().toString());
         LiSecuredPrefManager instance = LiSecuredPrefManager.getInstance();
         assert instance != null;
         String key = "test";
@@ -134,7 +135,7 @@ public class LiSecuredPrefManagerTest {
 
     @Test
     public void remove() throws Exception {
-        LiSecuredPrefManager.initialize("ThisIsASecretKey");
+        LiSecuredPrefManager.initialize(UUID.randomUUID().toString());
         LiSecuredPrefManager instance = LiSecuredPrefManager.getInstance();
         assert instance != null;
         String key = "test";
@@ -148,7 +149,7 @@ public class LiSecuredPrefManagerTest {
     @Test
     public void remove_null_context() throws Exception {
         thrown.expect(IllegalArgumentException.class);
-        LiSecuredPrefManager.initialize("ThisIsASecretKey");
+        LiSecuredPrefManager.initialize(UUID.randomUUID().toString());
         LiSecuredPrefManager instance = LiSecuredPrefManager.getInstance();
         assert instance != null;
         String key = "test";
@@ -161,7 +162,7 @@ public class LiSecuredPrefManagerTest {
     @Test
     public void remove_null_key() throws Exception {
         thrown.expect(IllegalArgumentException.class);
-        LiSecuredPrefManager.initialize("ThisIsASecretKey");
+        LiSecuredPrefManager.initialize(UUID.randomUUID().toString());
         LiSecuredPrefManager instance = LiSecuredPrefManager.getInstance();
         assert instance != null;
         String key = "test";
@@ -174,7 +175,7 @@ public class LiSecuredPrefManagerTest {
     @Test
     public void remove_null_context_null_key() throws Exception {
         thrown.expect(IllegalArgumentException.class);
-        LiSecuredPrefManager.initialize("ThisIsASecretKey");
+        LiSecuredPrefManager.initialize(UUID.randomUUID().toString());
         LiSecuredPrefManager instance = LiSecuredPrefManager.getInstance();
         assert instance != null;
         String key = "test";

--- a/li-android-sdk-core/src/test/java/lithium/community/android/sdk/model/LiAvatarTest.java
+++ b/li-android-sdk-core/src/test/java/lithium/community/android/sdk/model/LiAvatarTest.java
@@ -43,9 +43,9 @@ public class LiAvatarTest {
         assertEquals(profile, liAvatar.getProfile());
         assertEquals(message, liAvatar.getMessage());
         assertEquals("{\"MESSAGE_IMAGE_URL\":\"This is Avatar\",\"PROFILE_IMAGE_URL\":\"profile\"}",
-                liAvatar.jsonSerialize().toString());
+                liAvatar.serialize().toString());
         LiAvatar liAvatar1 = new LiAvatar();
-        liAvatar1 = LiAvatar.jsonDeserialize(liAvatar.jsonSerialize());
+        liAvatar1 = LiAvatar.deserialize(liAvatar.serialize());
         assertEquals(profile, liAvatar1.getProfile());
         assertEquals(message, liAvatar1.getMessage());
     }

--- a/li-android-sdk-core/src/test/java/lithium/community/android/sdk/model/response/LiUserTest.java
+++ b/li-android-sdk-core/src/test/java/lithium/community/android/sdk/model/response/LiUserTest.java
@@ -239,7 +239,7 @@ public class LiUserTest {
                         + ".com\\/t5\\/user\\/viewprofilepage\\/user-id\\/52295\",\"USER_ID\":\"123456\","
                         + "\"USER_AVATAR\":{\"MESSAGE_IMAGE_URL\":\"AVATAR\",\"PROFILE_IMAGE_URL\":\"null\"},"
                         + "\"USER_HREF\":\"\\/\\/messages\\/\\/213824\"}",
-                liUser.jsonSerialize().toString());
+                liUser.serialize().toString());
 
     }
 
@@ -262,8 +262,8 @@ public class LiUserTest {
         email.setValue(EMAIL);
         liUser.setEmail(email);
         liUser.setAvatar(avatar);
-        JSONObject jsonObject = liUser.jsonSerialize();
-        LiUser liUser1 = liUser.jsonDeserialize(jsonObject);
+        JSONObject jsonObject = liUser.serialize();
+        LiUser liUser1 = liUser.deserialize(jsonObject);
         Assert.assertEquals(liUser.getId(), liUser1.getId());
         Assert.assertEquals(liUser.getProfilePageUrl(), liUser1.getProfilePageUrl());
         Assert.assertEquals(liUser.getHref(), liUser1.getHref());

--- a/li-android-sdk-core/src/test/java/lithium/community/android/sdk/rest/LiAuthRestClientTest.java
+++ b/li-android-sdk-core/src/test/java/lithium/community/android/sdk/rest/LiAuthRestClientTest.java
@@ -124,7 +124,7 @@ public class LiAuthRestClientTest {
         final Response finalResponse = response;
         try {
             doReturn(liBaseResponse).when(liAuthRestClient).getLiBaseResponseFromResponse(response);
-        } catch (IOException | LiRestResponseException ignored) {
+        } catch (IOException ignored) {
         }
         final IOException excep = mock(IOException.class);
         when(excep.getMessage()).thenReturn("Error authorizeAsync");
@@ -297,7 +297,7 @@ public class LiAuthRestClientTest {
         final Response finalResponse = response;
         try {
             doReturn(liBaseResponse).when(liAuthRestClient).getLiBaseResponseFromResponse(finalResponse);
-        } catch (IOException | LiRestResponseException ignored) {
+        } catch (IOException ignored) {
         }
         final IOException excep = mock(IOException.class);
         when(excep.getMessage()).thenReturn(EXCEPTION_CAUSE);

--- a/li-android-sdk-core/src/test/java/lithium/community/android/sdk/rest/LiCallTaskTest.java
+++ b/li-android-sdk-core/src/test/java/lithium/community/android/sdk/rest/LiCallTaskTest.java
@@ -32,7 +32,6 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.io.IOException;
-import java.util.Arrays;
 
 import lithium.community.android.sdk.exception.LiRestResponseException;
 import lithium.community.android.sdk.manager.LiClientManager;
@@ -43,8 +42,6 @@ import okhttp3.Request;
 import okhttp3.Response;
 import okhttp3.ResponseBody;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.mock;
 
@@ -53,51 +50,64 @@ import static org.powermock.api.mockito.PowerMockito.mock;
 public class LiCallTaskTest {
 
     private Call call;
-    private LiBaseResponse liBaseResponse;
     private LiCallTask callTask;
-    private Response response;
-    private ResponseBody body;
-    private Request request;
-    private Protocol protocol;
-    private LiClientManager liClientManager;
-    private LiRestv2Client liRestClient;
-    private Gson gson;
-    private LiBaseRestRequest restRequest;
-    private LiAsyncRequestCallback responseCallback;
 
     @Before
-    public void setUp() throws LiRestResponseException, IOException {
+    public void setUp() throws IOException {
 
-        gson = PowerMockito.mock(Gson.class);
-        restRequest = PowerMockito.mock(LiBaseRestRequest.class);
-        responseCallback = PowerMockito.mock(LiAsyncRequestCallback.class);
-        liRestClient = PowerMockito.mock(LiRestv2Client.class);
-        byte[] bytes = new byte[100];
-        Arrays.fill(bytes, (byte) 0);
-        body = ResponseBody.create(MediaType.parse("application/json; charset=utf-8"), bytes);
-        request = PowerMockito.mock(Request.class);
-        protocol = PowerMockito.mock(Protocol.class);
-        response = PowerMockito.mock(Response.class);
+        LiRestv2Client liRestClient = PowerMockito.mock(LiRestv2Client.class);
+
+        String json = "{\n" +
+                "  \"status\": \"success\",\n" +
+                "  \"message\": \"\",\n" +
+                "  \"http_code\": 200,\n" +
+                "  \"data\": {\n" +
+                "    \"type\": \"messages\",\n" +
+                "    \"list_item_type\": \"message\",\n" +
+                "    \"size\": 1,\n" +
+                "    \"items\": [\n" +
+                "      {\n" +
+                "        \"type\": \"message\",\n" +
+                "        \"conversation\": {\n" +
+                "          \"type\": \"conversation\",\n" +
+                "          \"last_post_time\": \"2016-06-22T08:46:02.737-07:00\"\n" +
+                "        }\n" +
+                "      }\n" +
+                "    ]\n" +
+                "  },\n" +
+                "  \"metadata\": {}\n" +
+                "}";
+        byte[] bytes = json.getBytes();
+
+        ResponseBody body = ResponseBody.create(MediaType.parse("application/json; charset=utf-8"), bytes);
+        Request request = PowerMockito.mock(Request.class);
+
+        Protocol protocol = PowerMockito.mock(Protocol.class);
+
         Response.Builder builder = new Response.Builder();
         builder.code(200);
         builder.message("test");
         builder.body(body);
         builder.request(request);
         builder.protocol(protocol);
-        response = builder.build();
+        Response response = builder.build();
+
         PowerMockito.mockStatic(LiClientManager.class);
-        liClientManager = mock(LiClientManager.class);
+
+        LiClientManager liClientManager = mock(LiClientManager.class);
         when(liClientManager.getRestClient()).thenReturn(liRestClient);
-        when(liRestClient.getGson()).thenReturn(gson);
-        when(gson.fromJson(anyString(), (Class<Object>) any())).thenReturn(null);
+        when(liRestClient.getGson()).thenReturn(new Gson());
+
         call = PowerMockito.mock(Call.class);
         callTask = new LiCallTask(call);
+
         when(call.execute()).thenReturn(response);
+
         MockitoAnnotations.initMocks(this);
     }
 
     @Test
-    public void executeTest() throws LiRestResponseException, IOException {
+    public void executeTest() throws LiRestResponseException {
         Assert.assertEquals(200, callTask.execute().getHttpCode());
         PowerMockito.verifyStatic();
     }


### PR DESCRIPTION
* Refactor URL paths and response schema for all API calls.
* Add better error and debug logs.
* reuse `Gson` instance.
* Use `UriBuilder` instead of string concatenations.
* Improve unit test cases.
* Improve constant variable names for version.
* Improve `proguard` config.
* Refactor and deprecate the API Gateway Host in `LiAppCredentials`.
* Remove unnecessary throws clause in interface implementations.
* Check if SDK is initialized and a user is logged in before updating or saving device id for push notifications.
* Remove unnecessary use of primitive wrappers.