### PR TITLE
To enable anonymous browsing through current SDK APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 .DS_Store
 /build
 /captures
+/.idea/

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/rest/LiRestClient.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/rest/LiRestClient.java
@@ -455,11 +455,11 @@ public abstract class LiRestClient {
     private Request.Builder buildRequestHeaders(Context context, Request.Builder requestBuilder) {
 
         if (!TextUtils.isEmpty(sdkManager.getAuthToken())) {
+            requestBuilder.header(LiRequestHeaderConstants.LI_REQUEST_AUTH_SERVICE_KEY, LiRequestHeaderConstants.LI_REQUEST_AUTH_SERVICE_VALUE);
             requestBuilder.header(LiAuthConstants.AUTHORIZATION, LiAuthConstants.BEARER + sdkManager.getAuthToken());
         }
         requestBuilder.header(LiRequestHeaderConstants.LI_REQUEST_CONTENT_TYPE, "application/json");
         requestBuilder.header(LiRequestHeaderConstants.LI_REQUEST_CLIENT_ID, sdkManager.getCredentials().getClientKey());
-        requestBuilder.header(LiRequestHeaderConstants.LI_REQUEST_AUTH_SERVICE_KEY, LiRequestHeaderConstants.LI_REQUEST_AUTH_SERVICE_VALUE);
         addLSIRequestHeaders(context, requestBuilder);
 
         return requestBuilder;

--- a/li-android-sdk-core/src/main/java/lithium/community/android/sdk/rest/LiRestV2Request.java
+++ b/li-android-sdk-core/src/main/java/lithium/community/android/sdk/rest/LiRestV2Request.java
@@ -20,6 +20,7 @@ import android.content.Context;
 
 import java.util.Map;
 
+import lithium.community.android.sdk.manager.LiSDKManager;
 import okhttp3.MediaType;
 import okhttp3.RequestBody;
 
@@ -44,7 +45,7 @@ public class LiRestV2Request extends LiBaseRestRequest {
      * Preparing rest v2 request for GET call when no additional headers are present.
      */
     public LiRestV2Request(Context context, String queryParams, String type) {
-        super(context, RestMethod.GET, null, null, true);
+        super(context, RestMethod.GET, null, null, LiSDKManager.getInstance().isUserLoggedIn());
         addQueryParam(queryParams);
         this.type = type;
     }


### PR DESCRIPTION
Made LiRestV2Request dependent on SDK manager logged in state, to identify whether authenticated request or not - ideally the setV2RestCLient dependency should be an injection instead of local creation, changin that would lead a significant design change. Also, in LiRestClient added 'Auth-Service-Authorization' as part of authenticated requests only